### PR TITLE
Avoid using a deprecated include on Linux

### DIFF
--- a/stats/albatross_stats_stubs.c
+++ b/stats/albatross_stats_stubs.c
@@ -11,11 +11,6 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sys/user.h>
-#ifdef __Linux__
-#include <linux/sysctl.h>
-#else
-#include <sys/sysctl.h>
-#endif
 #include <net/if.h>
 
 #define Val32 caml_copy_int32
@@ -33,6 +28,7 @@ CAMLprim value vmmanage_sysconf_clock_tick(value unit) {
 }
 
 #ifdef __FreeBSD__
+#include <sys/sysctl.h>
 #include <net/if_mib.h>
 #include <vmmapi.h>
 

--- a/stats/albatross_stats_stubs.c
+++ b/stats/albatross_stats_stubs.c
@@ -11,7 +11,11 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sys/user.h>
+#ifdef __Linux__
+#include <linux/sysctl.h>
+#else
 #include <sys/sysctl.h>
+#endif
 #include <net/if.h>
 
 #define Val32 caml_copy_int32


### PR DESCRIPTION
From `/usr/include/sys/sysctl.h` on my Debian Sid:
```
#warning "The <sys/sysctl.h> header is deprecated and will be removed."
```