### PR TITLE
tmpdir and dbdir: infer default from uname before command processing

### DIFF
--- a/client/albatross_client_bistro.ml
+++ b/client/albatross_client_bistro.ml
@@ -121,7 +121,8 @@ let get _ endp cert key ca name =
 let destroy _ endp cert key ca name =
   jump endp cert key ca name (`Unikernel_cmd `Unikernel_destroy)
 
-let create _ endp cert key ca force name image cpuid memory argv block network compression restart_on_fail exit_code =
+let create _ endp cert key ca dbdir force name image cpuid memory argv block network compression restart_on_fail exit_code =
+  Albatross_cli.set_dbdir dbdir;
   match Albatross_cli.create_vm force image cpuid memory argv block network compression restart_on_fail exit_code with
   | Ok cmd -> jump endp cert key ca name (`Unikernel_cmd cmd)
   | Error (`Msg msg) -> failwith msg
@@ -233,7 +234,7 @@ let create_cmd =
     [`S "DESCRIPTION";
      `P "Creates a virtual machine."]
   in
-  Term.(const create $ setup_log $ destination $ ca_cert $ ca_key $ server_ca $ force $ vm_name $ image $ cpu $ vm_mem $ args $ block $ net $ compress_level 9 $ restart_on_fail $ exit_code),
+  Term.(const create $ setup_log $ destination $ ca_cert $ ca_key $ server_ca $ dbdir $ force $ vm_name $ image $ cpu $ vm_mem $ args $ block $ net $ compress_level 9 $ restart_on_fail $ exit_code),
   Term.info "create" ~doc ~man ~exits
 
 let console_cmd =

--- a/client/albatross_client_local.ml
+++ b/client/albatross_client_local.ml
@@ -63,7 +63,8 @@ let get _ opt_socket name =
 let destroy _ opt_socket name =
   jump opt_socket name (`Unikernel_cmd `Unikernel_destroy)
 
-let create _ opt_socket force name image cpuid memory argv block network compression restart_on_fail exit_code tmpdir =
+let create _ opt_socket dbdir force name image cpuid memory argv block network compression restart_on_fail exit_code tmpdir =
+  Albatross_cli.set_dbdir dbdir;
   match Albatross_cli.create_vm force image cpuid memory argv block network compression restart_on_fail exit_code with
   | Ok cmd -> jump opt_socket name (`Unikernel_cmd cmd) tmpdir
   | Error (`Msg msg) -> Error (`Msg msg)
@@ -167,7 +168,7 @@ let create_cmd =
     [`S "DESCRIPTION";
      `P "Creates a virtual machine."]
   in
-  Term.(term_result (const create $ setup_log $ socket $ force $ vm_name $ image $ cpu $ vm_mem $ args $ block $ net $ compress_level 0 $ restart_on_fail $ exit_code $ tmpdir)),
+  Term.(term_result (const create $ setup_log $ socket $ dbdir $ force $ vm_name $ image $ cpu $ vm_mem $ args $ block $ net $ compress_level 0 $ restart_on_fail $ exit_code $ tmpdir)),
   Term.info "create" ~doc ~man ~exits
 
 let console_cmd =

--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -305,39 +305,33 @@ let version =
   Fmt.strf "version %%VERSION%% protocol version %a"
     Vmm_commands.pp_version Vmm_commands.current
 
-let tmpdir =
-  let doc = "Albatross temporary directory (defaults to /var/run/albatross on FreeBSD, /run/albatross on Linux)" in
-  Arg.(value & opt (some dir) None & info [ "tmpdir" ] ~doc)
+let default_tmpdir =
+  match Lazy.force Vmm_unix.uname with
+  | FreeBSD -> "/var/run/albatross"
+  | Linux -> "/run/albatross"
 
-let set_tmpdir = function
-  | Some path ->
-    begin match Fpath.of_string path with
-      | Ok path -> Vmm_core.set_tmpdir path
-      | Error `Msg m -> invalid_arg m
-    end
-  | None ->
-    let path = match Lazy.force Vmm_unix.uname with
-      | FreeBSD -> Fpath.(v "/var" / "run" / "albatross")
-      | Linux -> Fpath.(v "/run" / "albatross")
-    in
-    Vmm_core.set_tmpdir path
+let tmpdir =
+  let doc = "Albatross temporary directory" in
+  Arg.(value & opt dir default_tmpdir & info [ "tmpdir" ] ~doc)
+
+let set_tmpdir path =
+  match Fpath.of_string path with
+  | Ok path -> Vmm_core.set_tmpdir path
+  | Error `Msg m -> invalid_arg m
+
+let default_dbdir =
+  match Lazy.force Vmm_unix.uname with
+  | Vmm_unix.FreeBSD -> "/var/db/albatross"
+  | Linux -> "/var/lib/albatross"
 
 let dbdir =
-  let doc = "Albatross database directory (defaults to /var/db/albatross on FreeBSD, /var/lib/albatross on Linux)" in
-  Arg.(value & opt (some dir) None & info [ "dbdir" ] ~doc)
+  let doc = "Albatross database directory" in
+  Arg.(value & opt dir default_dbdir & info [ "dbdir" ] ~doc)
 
-let set_dbdir = function
-  | Some path ->
-    begin match Fpath.of_string path with
-      | Ok path -> Vmm_unix.set_dbdir path
-      | Error `Msg m -> invalid_arg m
-    end
-  | None ->
-    let path = match Lazy.force Vmm_unix.uname with
-      | Vmm_unix.FreeBSD -> Fpath.(v "/var" / "db" / "albatross")
-      | Linux -> Fpath.(v "/var" / "lib" / "albatross")
-    in
-    Vmm_unix.set_dbdir path
+let set_dbdir path =
+  match Fpath.of_string path with
+  | Ok path -> Vmm_unix.set_dbdir path
+  | Error `Msg m -> invalid_arg m
 
 let enable_stats =
   let doc = "Connect to albatross-stats to report statistics" in


### PR DESCRIPTION
now in the man pages the directory is printed (OS specific), no need to
explicitly name it in the help text. in addition, dbdir is passed to
albatross_client_local|bistro (so solo5-elftool is searched in dbdir as well).

this fixes albatross_client_local where no opam is installed. this is temporary
until solo5 tenders and utils are packaged by the operating system (at which
point, dbdir will only be used for the state file). (see https://github.com/Solo5/solo5/issues/487)