### PR TITLE
FreeBSD albatross_daemon rc script: extend PATH, revise unikernel_get and unikernel_info commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ researched on.
 Albatross consists of a set of binaries. Several daemons, which communicate in a
 request-response style over Unix domain sockets, are run in the host system:
 - `albatrossd`: privileged to create and destroy unikernels
-- `albatross_console`: reads the console output of unikernels
-- `albatross_log`: event log
-- `albatross_stats`: statistics gathering (rusage, ifstat, BHyve debug counters)
-- `albatross_tls_inetd`: remote deployment via TLS and inetd (an alternative is `albatross_tls_endpoint`)
-- `albatross_influx`: statistic reporting from `albatross_stats` to influx
+- `albatross-console`: reads the console output of unikernels
+- `albatross-log`: event log
+- `albatross-stats`: statistics gathering (rusage, ifstat, BHyve debug counters)
+- `albatross-tls-inetd`: remote deployment via TLS and inetd (an alternative is `albatross-tls-endpoint`)
+- `albatross-influx`: statistic reporting from `albatross-stats` to influx
 
 The main daemon is the privileged `albatrossd`, which supervises unikernels. It opens
 a listening Unix domain socket, reads the persisted unikernel configuration,
@@ -51,39 +51,38 @@ starts these unikernels, and awaits commands. Access can be regulated by Unix
 file permissions, only those users who can write to that socket can send
 commands.
 
-`Albatross_console` does not keep any persistent state, but a ring buffer of console
+`Albatross-console` does not keep any persistent state, but a ring buffer of console
 output from each unikernel. These messages can be retrieved by a client, as a
 stream of messages (history, and whenever a new line is output, it is send to
 the interested client). Each unikernel output can only be read by a single
 client, to avoid amplification of traffic if lots of clients are connected.
-`Albatrossd` sends a message to `albatross_console` whenever a new unikernel is started,
-upon reception `albatross_console` opens and reads the fifo which the unikernel will
+`Albatrossd` sends a message to `albatross-console` whenever a new unikernel is started,
+upon reception `albatross-console` opens and reads the fifo which the unikernel will
 write their standard output to.
 
-`Albatross_log` keeps a persistent event log for albatross, can be read by clients.
+`Albatross-log` keeps a persistent event log for albatross, can be read by clients.
 
-`Albatross_stats` gathers periodically statistics (memory, CPU, network, hypervisor)
+`Albatross-stats` gathers periodically statistics (memory, CPU, network, hypervisor)
 from all running unikernels.
 
-`Albatross_tls_inetd` is executed via inetd (socket activation), and proxy
+`Albatross-tls-inetd` is executed via inetd (socket activation), and proxy
 requests from remote clients to the respective daemons described above. It
 enforce client authentication, and use the commen names of the client
 certificate chain as administrative domain. The policies are embedded in CA
 certificates, the command is embedded in the leaf certificate. The
-`albatross_tls_endpoint` is an alternative, which listen on a TCP port and
+`albatross-tls-endpoint` is an alternative, which listen on a TCP port and
 executes an asynchronous task for each incoming request.
 
 The following command-line applications for local and remote management are provided:
-- `albatross_client_local`: sends a command locally to the Unix domain sockets
-- `albatross_client_remote_tls`: connects to a remote TLS endpoint and sends a command
-- `albatross_provision_request`: creates a certificate signing request containing a command
-- `albatross_provision_ca`: certificate authority operations: sign, generate, and revoke (NYI)
-- `albatross_client_bistro`: command line utility to execute a command remotely: request, sign, remote (do not use in production, requires CA key locally)
+- `albatross-client-local`: sends a command locally to the Unix domain sockets
+- `albatross-client-remote-tls`: connects to a remote TLS endpoint and sends a command
+- `albatross-provision-request`: creates a certificate signing request containing a command
+- `albatross-provision-ca`: certificate authority operations: sign, generate, and revoke (NYI)
+- `albatross-client-bistro`: command line utility to execute a command remotely: request, sign, remote (do not use in production, requires CA key locally)
 
 ## Installation
 
-To install Albatross, run `opam pin add albatross
-https://github.com/roburio/albatross`.
+To install Albatross, run `opam install albatross`.
 
 Init scripts for FreeBSD are provided in the `packaging/FreeBSD/rc.d`
 subdirectory, and a script to create a FreeBSD package

--- a/albatross.opam
+++ b/albatross.opam
@@ -25,6 +25,7 @@ depends: [
   "jsonm"
   "x509" {>= "0.11.0"}
   "tls" {>= "0.12.2"}
+  "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-rng" {>= "0.8.0"}
   "asn1-combinators" {>= "0.2.0"}
@@ -34,6 +35,7 @@ depends: [
   "metrics" {>= "0.2.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
+  "hex"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/client/albatross_client_bistro.ml
+++ b/client/albatross_client_bistro.ml
@@ -311,7 +311,7 @@ let default_cmd =
     `P "$(tname) executes the provided subcommand on a remote albatross" ]
   in
   Term.(ret (const help $ setup_log $ destination $ Term.man_format $ Term.choice_names $ Term.pure None)),
-  Term.info "albatross_client_bistro" ~version ~doc ~man ~exits
+  Term.info "albatross-client-bistro" ~version ~doc ~man ~exits
 
 let cmds = [ help_cmd ;
              policy_cmd ; remove_policy_cmd ; add_policy_cmd ;

--- a/client/albatross_client_local.ml
+++ b/client/albatross_client_local.ml
@@ -263,7 +263,7 @@ let default_cmd =
     `P "$(tname) connects to albatrossd via a local socket" ]
   in
   Term.(ret (const help $ setup_log $ socket $ Term.man_format $ Term.choice_names $ Term.pure None)),
-  Term.info "albatross_client_local" ~version ~doc ~man ~exits
+  Term.info "albatross-client-local" ~version ~doc ~man ~exits
 
 let cmds = [ help_cmd ;
              policy_cmd ; remove_policy_cmd ; add_policy_cmd ;

--- a/client/albatross_client_remote_tls.ml
+++ b/client/albatross_client_remote_tls.ml
@@ -75,7 +75,7 @@ let cmd =
   in
   let exits = auth_exits @ exits in
   Term.(const run_client $ setup_log $ cas $ client_cert $ client_key $ destination),
-  Term.info "albatross_client_remote_tls" ~version ~doc ~man ~exits
+  Term.info "albatross-client-remote-tls" ~version ~doc ~man ~exits
 
 let () =
   match Term.eval cmd with

--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -346,7 +346,7 @@ let enable_stats =
 
 let retry_connections =
   let doc = "Number of retries when connecting to other daemons (log, console, stats etc). 0 aborts after one failure, -1 is unlimited retries." in
-  Arg.(value & opt int 0 & info [ "retry-connections" ] ~doc)
+  Arg.(value & opt int 2 & info [ "retry-connections" ] ~doc)
 
 let systemd_socket_activation =
   match Lazy.force Vmm_unix.uname with

--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -261,21 +261,21 @@ let args =
   let doc = "Boot arguments" in
   Arg.(value & opt_all string [] & info [ "arg" ] ~doc)
 
-let block =
-  let doc = "Block device name" in
-  Arg.(value & opt_all string [] & info [ "block" ] ~doc)
-
-let srv_bridge_c =
+let colon_separated_c =
   let parse s = match Astring.String.cut ~sep:":" s with
     | None -> `Ok (s, None)
-    | Some (srv, bri) -> `Ok (srv, Some bri)
+    | Some (a, b) -> `Ok (a, Some b)
   in
-  (parse, fun ppf (srv, bri) -> Fmt.pf ppf "%s:%s" srv
-       (match bri with None -> srv | Some bri -> bri))
+  (parse, fun ppf (a, b) -> Fmt.pf ppf "%s:%s" a
+       (match b with None -> a | Some b -> b))
+
+let block =
+  let doc = "Block device name (block or name:block-device-name)" in
+  Arg.(value & opt_all colon_separated_c [] & info [ "block" ] ~doc)
 
 let net =
   let doc = "Network device names (bridge or name:bridge)" in
-  Arg.(value & opt_all srv_bridge_c [] & info [ "net" ] ~doc)
+  Arg.(value & opt_all colon_separated_c [] & info [ "net" ] ~doc)
 
 let restart_on_fail =
   let doc = "Restart on fail" in

--- a/daemon/albatross_console.ml
+++ b/daemon/albatross_console.ml
@@ -178,6 +178,6 @@ open Albatross_cli
 
 let cmd =
   Term.(term_result (const jump $ setup_log $ systemd_socket_activation $ influx $ tmpdir)),
-  Term.info "albatross_console" ~version
+  Term.info "albatross-console" ~version
 
 let () = match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1

--- a/daemon/albatross_influx.ml
+++ b/daemon/albatross_influx.ml
@@ -304,7 +304,7 @@ let cmd =
     `P "$(tname) connects to a albatross stats socket, pulls statistics and pushes them via TCP to influxdb" ]
   in
   Term.(term_result (const run_client $ setup_log $ influx $ opt_vm_name $ drop_label $ tmpdir)),
-  Term.info "albatross_influx" ~version ~doc ~man
+  Term.info "albatross-influx" ~version ~doc ~man
 
 let () =
   match Term.eval cmd

--- a/daemon/albatross_log.ml
+++ b/daemon/albatross_log.ml
@@ -193,6 +193,6 @@ let read_only =
 
 let cmd =
   Term.(const jump $ setup_log $ systemd_socket_activation $ file $ read_only $ influx $ tmpdir),
-  Term.info "albatross_log" ~version
+  Term.info "albatross-log" ~version
 
 let () = match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1

--- a/daemon/albatrossd.ml
+++ b/daemon/albatrossd.ml
@@ -152,9 +152,9 @@ let jump _ systemd influx tmpdir dbdir retries enable_stats =
          Vmm_lwt.connect Lwt_unix.PF_UNIX (Lwt_unix.ADDR_UNIX path) >>= function
          | Some x -> Lwt.return x
          | None when (retries <> 0) ->
-           Logs.err (fun m -> m "unable to connect to %a, retrying in 5 seconds"
+           Logs.err (fun m -> m "unable to connect to %a, retrying in 3 seconds"
                         pp_socket s);
-           Lwt_unix.sleep 5.0 >>= fun () ->
+           Lwt_unix.sleep 3.0 >>= fun () ->
            unix_connect ~retries:(retries - 1) s
          | None -> Lwt.fail_with (Fmt.strf "cannot connect to %a" pp_socket s)
        in

--- a/packaging/FreeBSD/MANIFEST
+++ b/packaging/FreeBSD/MANIFEST
@@ -6,13 +6,13 @@ www:	      https://github.com/roburio/albatross
 maintainer:   Hannes Mehnert <hannes@mehnert.org>
 prefix:	      /usr/local
 licenselogic: single
-licenses:     [NONE]
+licenses:     [ISCL]
 flatsize:     %%FLATSIZE%%
 categories:   [local]
 deps {
         gmp {
         origin = "math/gmp";
-        version = "6.1.2";
+        version = "6.2.1";
     }
 }
 scripts : {
@@ -76,12 +76,12 @@ messages [
      and server.key into /usr/local/etc/albatross, add this to /etc/inetd.conf:
 
         blackjack  stream  tcp     nowait  albatross \
-          /usr/local/libexec/albatross/alabtross_tls_inetd albatross_tls_inetd \
+          /usr/local/libexec/albatross/alabtross-tls-inetd albatross-tls-inetd \
           /usr/local/etc/albatross/cacert.pem \
           /usr/local/etc/albatross/server.pem \
           /usr/local/etc/albatross/server.key
 
-   * install solo5-hvt in /var/db/albatross
+   * install solo5-hvt and solo5-elftool in PATH or /var/db/albatross
 
 ===================================================================
 EOD;

--- a/packaging/FreeBSD/create_package.sh
+++ b/packaging/FreeBSD/create_package.sh
@@ -2,7 +2,7 @@
 
 basedir=$(realpath "$(dirname "$0")"/../..)
 pdir=$basedir/packaging/FreeBSD
-bdir=$basedir/_build/default
+bdir=$basedir/_build/install/default/bin
 #tmptmpl=$(basename "$0")
 #tmpd=$(mktemp -t "$tmptmpl")
 tmpd=$basedir/_build/stage
@@ -28,27 +28,23 @@ for f in albatross_log \
 do install -U $pdir/rc.d/$f $rcdir/$f; done
 
 # stage albatross app binaries
-for f in albatrossd albatross_log albatross_console albatross_influx; do
-    install -U $bdir/daemon/$f.exe $libexecdir/$f;
-done
+for f in albatrossd \
+             albatross-log \
+             albatross-console \
+             albatross-influx \
+             albatross-tls-endpoint \
+             albatross-tls-inetd \
+             albatross-stats
+do install -U $bdir/$f $libexecdir/$f; done
 
-for f in albatross_tls_endpoint albatross_tls_inetd; do
-    install -U $bdir/tls/$f.exe $libexecdir/$f;
-done
-
-install -U $bdir/stats/albatross_stats.exe $libexecdir/albatross_stats
-
-install -U $bdir/stats/albatross_stat_client.exe $sbindir/albatross_stat_client
-
-for f in albatross_client_local \
-             albatross_client_remote_tls \
-             albatross_client_bistro \
-             albatross_client_inspect_dump
-do install -U $bdir/client/$f.exe $sbindir/$f; done
-
-for f in albatross_provision_ca albatross_provision_request; do
-    install -U $bdir/provision/$f.exe $sbindir/$f;
-done
+for f in albatross-stat-client \
+             albatross-client-local \
+             albatross-client-remote-tls \
+             albatross-client-bistro \
+             albatross-client-inspect-dump \
+             albatross-provision-ca \
+             albatross-provision-request
+do install -U $bdir/$f $sbindir/$f; done
 
 # create +MANIFEST
 flatsize=$(find "$rootdir" -type f -exec stat -f %z {} + |

--- a/packaging/FreeBSD/rc.d/albatross_console
+++ b/packaging/FreeBSD/rc.d/albatross_console
@@ -29,7 +29,7 @@ start_cmd="albatross_console_start"
 : ${albatross_console_user:="albatross"}
 
 pidfile="/var/run/albatross_console.pid"
-procname="/usr/local/libexec/albatross/albatross_console"
+procname="/usr/local/libexec/albatross/albatross-console"
 
 albatross_console_start () {
     echo "Starting ${name}."

--- a/packaging/FreeBSD/rc.d/albatross_daemon
+++ b/packaging/FreeBSD/rc.d/albatross_daemon
@@ -21,6 +21,8 @@
 
 . /etc/rc.subr
 
+export PATH=$PATH:/usr/local/sbin:/usr/local/bin
+
 name=albatross_daemon
 rcvar=${name}_enable
 desc="Albatross service"

--- a/packaging/FreeBSD/rc.d/albatross_influx
+++ b/packaging/FreeBSD/rc.d/albatross_influx
@@ -31,7 +31,7 @@ start_precmd="albatross_influx_precmd"
 : ${albatross_influx_user:="albatross"}
 
 pidfile="/var/run/albatross_influx.pid"
-procname="/usr/local/libexec/albatross/albatross_influx"
+procname="/usr/local/libexec/albatross/albatross-influx"
 
 #
 # force_depend script [rcvar]

--- a/packaging/FreeBSD/rc.d/albatross_log
+++ b/packaging/FreeBSD/rc.d/albatross_log
@@ -30,7 +30,7 @@ start_precmd="albatross_log_precmd"
 : ${albatross_log_user:="albatross"}
 
 pidfile="/var/run/albatross_log.pid"
-procname="/usr/local/libexec/albatross/albatross_log"
+procname="/usr/local/libexec/albatross/albatross-log"
 logfile="/var/log/albatross"
 
 albatross_log_precmd () {

--- a/packaging/FreeBSD/rc.d/albatross_stat
+++ b/packaging/FreeBSD/rc.d/albatross_stat
@@ -29,7 +29,7 @@ start_cmd="albatross_stat_start"
 : ${albatross_stat_user:="albatross"}
 
 pidfile="/var/run/albatross_stat.pid"
-procname="/usr/local/libexec/albatross/albatross_stats"
+procname="/usr/local/libexec/albatross/albatross-stats"
 
 albatross_stat_start () {
     echo "Starting ${name}."

--- a/packaging/FreeBSD/rc.d/albatross_tls
+++ b/packaging/FreeBSD/rc.d/albatross_tls
@@ -31,7 +31,7 @@ start_precmd="albatross_tls_precmd"
 : ${albatross_tls_user:="albatross"}
 
 pidfile="/var/run/albatross_tls.pid"
-procname="/usr/local/libexec/albatross/albatross_tls_endpoint"
+procname="/usr/local/libexec/albatross/albatross-tls-endpoint"
 
 #
 # force_depend script [rcvar]

--- a/packaging/Linux/README.md
+++ b/packaging/Linux/README.md
@@ -6,8 +6,7 @@ If you modify `Vmm_core.socket_path` you must modify the corresponding `.socket`
 
 1) You need to build the `albatross` tooling in this repository
 2) To run unikernels, you need to build and install solo5-elftool and at least one of the tenders: solo5-hvt and solo5-spt. They can be installed somewhere in PATH or in /var/lib/albatross/.
-2) You need to build a binary with one of the tenders (solo5-hvt, solo5-spt) to deploy.
 3) See [`install.sh`](./install.sh) for commands required to deploy it.
 4) `sudo journalctl -fu albatross'*'.service`
 5) ideally, once the services are up and running, you would be able to issue this command to deploy a unikernel:
-   `sudo albatross-client-local helloworld /path/to/hello_world.spt`
+   `sudo albatross-client-local create helloworld /path/to/hello_world.spt`

--- a/provision/albatross_provision_ca.ml
+++ b/provision/albatross_provision_ca.ml
@@ -157,7 +157,7 @@ let default_cmd =
     `P "$(tname) does CA operations (creation, sign, etc.)" ]
   in
   Term.(ret (const help $ setup_log $ Term.man_format $ Term.choice_names $ Term.pure None)),
-  Term.info "albatross_provision_ca" ~version ~doc ~man
+  Term.info "albatross-provision-ca" ~version ~doc ~man
 
 let cmds = [ help_cmd ; sign_cmd ; generate_cmd ; (* TODO revoke_cmd *)]
 

--- a/provision/albatross_provision_request.ml
+++ b/provision/albatross_provision_request.ml
@@ -208,7 +208,7 @@ let default_cmd =
     `P "$(tname) creates a certificate signing request for Albatross" ]
   in
   Term.(ret (const help $ setup_log $ Term.man_format $ Term.choice_names $ Term.pure None)),
-  Term.info "albatross_provision_request" ~version ~doc ~man
+  Term.info "albatross-provision-request" ~version ~doc ~man
 
 let cmds = [ help_cmd ;
              policy_cmd ; remove_policy_cmd ; add_policy_cmd ;

--- a/src/dune
+++ b/src/dune
@@ -3,4 +3,5 @@
   (public_name albatross)
   (wrapped false)
   (libraries rresult logs ipaddr bos ptime astring duration cstruct jsonm
-             decompress lwt lwt.unix ptime.clock.os asn1-combinators metrics))
+             decompress lwt lwt.unix ptime.clock.os asn1-combinators metrics
+             mirage-crypto hex))

--- a/src/vmm_commands.ml
+++ b/src/vmm_commands.ml
@@ -62,6 +62,8 @@ type unikernel_cmd = [
   | `Unikernel_force_create of Unikernel.config
   | `Unikernel_destroy
   | `Unikernel_get
+  | `Old_unikernel_info
+  | `Old_unikernel_get
 ]
 
 let pp_unikernel_cmd ppf = function
@@ -70,6 +72,8 @@ let pp_unikernel_cmd ppf = function
   | `Unikernel_force_create config -> Fmt.pf ppf "vm force create %a" Unikernel.pp_config config
   | `Unikernel_destroy -> Fmt.string ppf "unikernel destroy"
   | `Unikernel_get -> Fmt.string ppf "unikernel get"
+  | `Old_unikernel_info -> Fmt.string ppf "old unikernel info"
+  | `Old_unikernel_get -> Fmt.string ppf "old unikernel get"
 
 type policy_cmd = [
   | `Policy_info
@@ -134,7 +138,9 @@ type success = [
   | `Empty
   | `String of string
   | `Policies of (Name.t * Policy.t) list
-  | `Unikernels of (Name.t * Unikernel.config) list
+  | `Old_unikernels of (Name.t * Unikernel.config) list
+  | `Unikernel_info of (Name.t * Unikernel.info) list
+  | `Unikernel_image of bool * Cstruct.t
   | `Block_devices of (Name.t * int * bool) list
 ]
 
@@ -150,7 +156,9 @@ let pp_success ppf = function
   | `Empty -> Fmt.string ppf "success"
   | `String data -> Fmt.pf ppf "success: %s" data
   | `Policies ps -> my_fmt_list "no policies" Fmt.(pair ~sep:(unit ": ") Name.pp Policy.pp) ppf ps
-  | `Unikernels vms -> my_fmt_list "no unikernels" Fmt.(pair ~sep:(unit ": ") Name.pp Unikernel.pp_config) ppf vms
+  | `Old_unikernels vms -> my_fmt_list "no unikernels" Fmt.(pair ~sep:(unit ": ") Name.pp Unikernel.pp_config) ppf vms
+  | `Unikernel_info infos -> my_fmt_list "no unikernels" Fmt.(pair ~sep:(unit ": ") Name.pp Unikernel.pp_info) ppf infos
+  | `Unikernel_image (compressed, image) -> Fmt.pf ppf "image (compression %B) %d bytes" compressed (Cstruct.len image)
   | `Block_devices blocks -> my_fmt_list "no block devices" pp_block ppf blocks
 
 type res = [

--- a/src/vmm_commands.mli
+++ b/src/vmm_commands.mli
@@ -36,6 +36,8 @@ type unikernel_cmd = [
   | `Unikernel_force_create of Unikernel.config
   | `Unikernel_destroy
   | `Unikernel_get
+  | `Old_unikernel_info
+  | `Old_unikernel_get
 ]
 
 type policy_cmd = [
@@ -81,7 +83,9 @@ type success = [
   | `Empty
   | `String of string
   | `Policies of (Name.t * Policy.t) list
-  | `Unikernels of (Name.t * Unikernel.config) list
+  | `Old_unikernels of (Name.t * Unikernel.config) list
+  | `Unikernel_info of (Name.t * Unikernel.info) list
+  | `Unikernel_image of bool * Cstruct.t
   | `Block_devices of (Name.t * int * bool) list
 ]
 

--- a/src/vmm_core.ml
+++ b/src/vmm_core.ml
@@ -450,7 +450,7 @@ module Log = struct
     | `Login of Name.t * Ipaddr.V4.t * int
     | `Logout of Name.t * Ipaddr.V4.t * int
     | `Startup
-    | `Unikernel_start of Name.t * int * (string * string) list * (string * Name.t) list
+    | `Unikernel_start of Name.t * Cstruct.t * int * (string * string) list * (string * Name.t) list
     | `Unikernel_stop of Name.t * int * process_exit
     | `Hup
   ]
@@ -459,7 +459,7 @@ module Log = struct
     | `Startup -> []
     | `Login (name, _, _) -> name
     | `Logout (name, _, _) -> name
-    | `Unikernel_start (name, _, _ ,_) -> name
+    | `Unikernel_start (name, _, _, _ ,_) -> name
     | `Unikernel_stop (name, _, _) -> name
     | `Hup -> []
 
@@ -467,9 +467,11 @@ module Log = struct
     | `Startup -> Fmt.string ppf "startup"
     | `Login (name, ip, port) -> Fmt.pf ppf "%a login %a:%d" Name.pp name Ipaddr.V4.pp ip port
     | `Logout (name, ip, port) -> Fmt.pf ppf "%a logout %a:%d" Name.pp name Ipaddr.V4.pp ip port
-    | `Unikernel_start (name, pid, taps, blocks) ->
-      Fmt.pf ppf "%a started %d (taps %a, block %a)"
-        Name.pp name pid Fmt.(list ~sep:(unit "; ") (pair ~sep:(unit "=") string string)) taps
+    | `Unikernel_start (name, digest, pid, taps, blocks) ->
+      let `Hex hex_digest = Hex.of_cstruct digest in
+      Fmt.pf ppf "%a (digest: %s) started %d (taps %a, block %a)"
+        Name.pp name hex_digest
+        pid Fmt.(list ~sep:(unit "; ") (pair ~sep:(unit "=") string string)) taps
         Fmt.(list ~sep:(unit "; ") (pair ~sep:(unit "=") string Name.pp)) blocks
     | `Unikernel_stop (name, pid, code) ->
       Fmt.pf ppf "%a stopped %d with %a" Name.pp name pid pp_process_exit code

--- a/src/vmm_core.ml
+++ b/src/vmm_core.ml
@@ -206,7 +206,7 @@ module Unikernel = struct
     fail_behaviour : fail_behaviour;
     cpuid : int ;
     memory : int ;
-    block_devices : string list ;
+    block_devices : (string * string option) list ;
     bridges : (string * string option) list ;
     argv : string list option ;
   }
@@ -216,6 +216,12 @@ module Unikernel = struct
       (fun (net, bri) -> match bri with None -> net | Some s -> s)
       vm.bridges
 
+  let pp_opt_list ppf xs =
+    Fmt.(list ~sep:(unit ", ")
+           (pair ~sep:(unit " -> ") string string))
+      ppf
+      (List.map (fun (a, b) -> a, (match b with None -> a | Some b -> b)) xs)
+
   let pp_config ppf (vm : config) =
     Fmt.pf ppf "typ %a@ compression %B image %d bytes@ fail behaviour %a@ cpu %d@ %d MB memory@ block devices %a@ bridge %a@ argv %a"
       pp_typ vm.typ
@@ -223,10 +229,8 @@ module Unikernel = struct
       (Cstruct.len vm.image)
       pp_fail_behaviour vm.fail_behaviour
       vm.cpuid vm.memory
-      Fmt.(list ~sep:(unit ", ") string) vm.block_devices
-      Fmt.(list ~sep:(unit ", ")
-             (pair ~sep:(unit " -> ") string string))
-      (List.map (fun (a, b) -> a, (match b with None -> a | Some b -> b)) vm.bridges)
+      pp_opt_list vm.block_devices
+      pp_opt_list vm.bridges
       Fmt.(option ~none:(unit "no") (list ~sep:(unit " ") string)) vm.argv
 
   let restart_handler config =
@@ -245,7 +249,7 @@ module Unikernel = struct
     Fmt.pf ppf "pid %d@ taps %a (block %a) cmdline %a digest %s"
       vm.pid
       Fmt.(list ~sep:(unit ", ") string) vm.taps
-      Fmt.(list ~sep:(unit ", ") string) vm.config.block_devices
+      pp_opt_list vm.config.block_devices
       Bos.Cmd.pp vm.cmd
       hex_digest
 
@@ -254,7 +258,7 @@ module Unikernel = struct
     fail_behaviour : fail_behaviour;
     cpuid : int ;
     memory : int ;
-    block_devices : string list ;
+    block_devices : (string * string option) list ;
     bridges : (string * string option) list ;
     argv : string list option ;
     digest : Cstruct.t ;
@@ -272,10 +276,8 @@ module Unikernel = struct
       pp_typ info.typ
       pp_fail_behaviour info.fail_behaviour
       info.cpuid info.memory
-      Fmt.(list ~sep:(unit ", ") string) info.block_devices
-      Fmt.(list ~sep:(unit ", ")
-             (pair ~sep:(unit " -> ") string string))
-      (List.map (fun (a, b) -> a, (match b with None -> a | Some b -> b)) info.bridges)
+      pp_opt_list info.block_devices
+      pp_opt_list info.bridges
       Fmt.(option ~none:(unit "no") (list ~sep:(unit " ") string)) info.argv
       hex_digest
 end

--- a/src/vmm_core.mli
+++ b/src/vmm_core.mli
@@ -195,7 +195,7 @@ module Log : sig
     | `Login of Name.t * Ipaddr.V4.t * int
     | `Logout of Name.t * Ipaddr.V4.t * int
     | `Startup
-    | `Unikernel_start of Name.t * int * (string * string) list * (string * Name.t) list
+    | `Unikernel_start of Name.t * Cstruct.t * int * (string * string) list * (string * Name.t) list
     | `Unikernel_stop of Name.t * int * process_exit
     | `Hup
   ]

--- a/src/vmm_core.mli
+++ b/src/vmm_core.mli
@@ -97,9 +97,26 @@ module Unikernel : sig
     cmd : Bos.Cmd.t;
     pid : int;
     taps : string list;
+    digest : Cstruct.t;
   }
 
   val pp : t Fmt.t
+
+  type info = {
+    typ : typ ;
+    fail_behaviour : fail_behaviour;
+    cpuid : int ;
+    memory : int ;
+    block_devices : string list ;
+    bridges : (string * string option) list ;
+    argv : string list option ;
+    digest : Cstruct.t ;
+  }
+
+  val info : t -> info
+
+  val pp_info : info Fmt.t
+
 end
 
 module Stats : sig

--- a/src/vmm_core.mli
+++ b/src/vmm_core.mli
@@ -81,7 +81,7 @@ module Unikernel : sig
     fail_behaviour : fail_behaviour;
     cpuid : int ;
     memory : int ;
-    block_devices : string list ;
+    block_devices : (string * string option) list ;
     bridges : (string * string option) list ;
     argv : string list option ;
   }
@@ -107,7 +107,7 @@ module Unikernel : sig
     fail_behaviour : fail_behaviour;
     cpuid : int ;
     memory : int ;
-    block_devices : string list ;
+    block_devices : (string * string option) list ;
     bridges : (string * string option) list ;
     argv : string list option ;
     digest : Cstruct.t ;

--- a/src/vmm_resources.ml
+++ b/src/vmm_resources.ml
@@ -103,7 +103,7 @@ let use_blocks t name vm active =
   match vm.Unikernel.config.Unikernel.block_devices with
   | [] -> t
   | blocks ->
-    let block_names = List.map (Name.block_name name) blocks in
+    let block_names = List.map (fun (bd, _) -> Name.block_name name bd) blocks in
     List.fold_left (fun t' n -> set_block_usage t' n active) t block_names
 
 let remove_vm t name = match find_vm t name with
@@ -155,7 +155,7 @@ let check_vm t name vm =
       let used = vm_usage t dom in
       check_policy p used vm
   and block_ok =
-    List.fold_left (fun r block ->
+    List.fold_left (fun r (block, _) ->
         r >>= fun () ->
         let block_name = Name.block_name name block in
         match find_block t block_name with

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -224,7 +224,9 @@ let devices_match ~bridges ~block_devices (manifest_block, manifest_net) =
 
 let manifest_devices_match ~bridges ~block_devices image_file =
   solo5_image_devices image_file >>=
-  let bridges = List.map fst bridges in
+  let bridges = List.map fst bridges
+  and block_devices = List.map fst block_devices
+  in
   devices_match ~bridges ~block_devices
 
 let bridge_name (service, b) = match b with None -> service | Some b -> b

--- a/src/vmm_unix.mli
+++ b/src/vmm_unix.mli
@@ -39,4 +39,5 @@ val restore : ?name:string -> unit -> (Cstruct.t, [> R.msg | `NoFile ]) result
 val vm_device : Unikernel.t -> (string, [> R.msg ]) result
 
 val manifest_devices_match : bridges:(string * string option) list ->
-  block_devices:string list -> Fpath.t -> (unit, [> R.msg]) result
+  block_devices:(string * string option) list -> Fpath.t ->
+  (unit, [> R.msg]) result

--- a/src/vmm_unix.mli
+++ b/src/vmm_unix.mli
@@ -15,10 +15,10 @@ val set_dbdir : Fpath.t -> unit
 val check_commands : unit -> (unit, [> R.msg ]) result
 
 val prepare : Name.t -> Unikernel.config ->
-  ((string * string) list, [> R.msg ]) result
+  ((string * string) list * Cstruct.t, [> R.msg ]) result
 
 val exec : Name.t -> Unikernel.config -> (string * string) list ->
-  (string * Name.t) list -> (Unikernel.t, [> R.msg ]) result
+  (string * Name.t) list -> Cstruct.t -> (Unikernel.t, [> R.msg ]) result
 
 val free_system_resources : Name.t -> string list -> (unit, [> R.msg ]) result
 

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -211,7 +211,7 @@ let handle_create t name vm_config =
     dump_unikernels t ;
     let t, log_out =
       let start =
-        `Unikernel_start (name, vm.Unikernel.pid, taps, block_devices)
+        `Unikernel_start (name, vm.Unikernel.digest, vm.Unikernel.pid, taps, block_devices)
       in
       log t name start
     in

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -200,7 +200,8 @@ let handle_create t name vm_config =
            below needs to be called *)
     Vmm_resources.check_vm t.resources name vm_config >>= fun () ->
     let block_devices =
-      List.map (fun d -> d, Name.block_name name d)
+      List.map (fun (n, device) ->
+          n, Name.block_name name (match device with None -> n | Some a -> a))
         vm_config.Unikernel.block_devices
     in
     Vmm_unix.exec name vm_config taps block_devices digest >>| fun vm ->

--- a/stats/albatross_stat_client.ml
+++ b/stats/albatross_stat_client.ml
@@ -69,6 +69,6 @@ let vmname =
 
 let cmd =
   Term.(term_result (const jump $ setup_log $ pid $ vmname $ interval $ tmpdir)),
-  Term.info "albatross_stat_client" ~version
+  Term.info "albatross-stat-client" ~version
 
 let () = match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1

--- a/stats/albatross_stats.ml
+++ b/stats/albatross_stats.ml
@@ -91,6 +91,6 @@ let interval =
 
 let cmd =
   Term.(term_result (const jump $ setup_log $ systemd_socket_activation $ interval $ influx $ tmpdir)),
-  Term.info "albatross_stats" ~version
+  Term.info "albatross-stats" ~version
 
 let () = match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1

--- a/tls/albatross_tls_endpoint.ml
+++ b/tls/albatross_tls_endpoint.ml
@@ -58,6 +58,6 @@ let port =
 
 let cmd =
   Term.(const jump $ setup_log $ cacert $ cert $ key $ port $ tmpdir),
-  Term.info "albatross_tls_endpoint" ~version
+  Term.info "albatross-tls-endpoint" ~version
 
 let () = match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1

--- a/tls/albatross_tls_inetd.ml
+++ b/tls/albatross_tls_inetd.ml
@@ -26,6 +26,6 @@ open Cmdliner
 
 let cmd =
   Term.(const jump $ cacert $ cert $ key $ Albatross_cli.tmpdir),
-  Term.info "albatross_tls_inetd" ~version:Albatross_cli.version
+  Term.info "albatross-tls-inetd" ~version:Albatross_cli.version
 
 let () = match Term.eval cmd with `Ok () -> exit 0 | _ -> exit 1


### PR DESCRIPTION
This now includes /usr/local/bin and /usr/local/sbin in the PATH variable. The
solo5 binaries will likely be installed in these locations, and albatross_daemon
needs to be able to find them. Fixes #63.

The second commit revises unikernel_info and unikernel_get commands and fixes #61 in a backwards-compatible way.

The third commit revises the block device handling and fixes #49 in a backwards-compatible way.