### PR TITLE
improve block handling:

### DIFF
--- a/daemon/albatrossd.ml
+++ b/daemon/albatrossd.ml
@@ -6,7 +6,7 @@ open Vmm_core
 
 open Lwt.Infix
 
-let state = ref (Vmm_vmmd.init ())
+let state = ref Vmm_vmmd.empty
 
 let stub_data_out _ = Lwt.return_unit
 
@@ -141,6 +141,7 @@ let jump _ systemd influx tmpdir dbdir retries enable_stats =
   Sys.(set_signal sigpipe Signal_ignore);
   Albatross_cli.set_tmpdir tmpdir;
   Albatross_cli.set_dbdir dbdir;
+  state := Vmm_vmmd.init_block_devices !state;
   Rresult.R.error_msg_to_invalid_arg
     (Vmm_unix.check_commands ());
   match Vmm_vmmd.restore_unikernels () with

--- a/packaging/FreeBSD/MANIFEST
+++ b/packaging/FreeBSD/MANIFEST
@@ -40,6 +40,7 @@ EOD;
     post-install = <<EOD
 mkdir -p /var/run/albatross/util /var/run/albatross/fifo
 chown albatross:albatross /var/run/albatross/util /var/run/albatross/fifo
+mkdir -p -m 700 /var/db/albatross/block
 
 EOD;
     post-deinstall = <<EOD

--- a/src/vmm_vmmd.mli
+++ b/src/vmm_vmmd.mli
@@ -4,7 +4,9 @@ open Vmm_core
 
 type 'a t
 
-val init : unit -> 'a t
+val empty : 'a t
+
+val init_block_devices : 'a t -> 'a t
 
 val waiter : 'a t -> Name.t -> 'a t * 'a option
 

--- a/tls/vmm_tls.ml
+++ b/tls/vmm_tls.ml
@@ -100,5 +100,6 @@ let handle chain =
     | `Stats_cmd `Stats_subscribe
     | `Log_cmd (`Log_subscribe _)
     | `Unikernel_cmd _
-    | `Policy_cmd `Policy_info -> Ok (name, policies, v, wire)
+    | `Policy_cmd `Policy_info
+    | `Block_cmd _ -> Ok (name, policies, v, wire)
     | _ -> Error (`Msg "unexpected command")


### PR DESCRIPTION
- Vmm_resources.check_vm needs to check for the right block device
- the solo5-hvt/spt argument is --block:<>=<>, not --disk
- Vmm_tls: allow block commands
- Vmm_unix.find_block_devices creates dbdir / block_sub if it does not exist
  (previously, this lead to a crash of albatrossd)

In addition, Vmm_resources.check_policy returns more detailed error messages.