### PR TITLE
use the last version of decompress

### DIFF
--- a/albatross.opam
+++ b/albatross.opam
@@ -30,7 +30,8 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "asn1-combinators" {>= "0.2.0"}
   "duration"
-  "decompress" {>= "0.9.0" & < "1.0.0"}
+  "decompress" {>= "1.2.0"}
+  "bigstringaf"
   "checkseum"
   "metrics" {>= "0.2.0"}
   "metrics-lwt" {>= "0.2.0"}

--- a/src/dune
+++ b/src/dune
@@ -3,5 +3,5 @@
   (public_name albatross)
   (wrapped false)
   (libraries rresult logs ipaddr bos ptime astring duration cstruct jsonm
-             decompress lwt lwt.unix ptime.clock.os asn1-combinators metrics
-             mirage-crypto hex))
+             bigstringaf decompress.de decompress.zl lwt lwt.unix
+	     ptime.clock.os asn1-combinators metrics mirage-crypto hex))

--- a/src/vmm_compress.ml
+++ b/src/vmm_compress.ml
@@ -1,111 +1,36 @@
-(* copied n 2018-03-18 from github.com:mirage/decompress.git (bin/easy.ml)
-   (MIT licensed) at fa1551b19165503fc77da6da99411fa59b6a7f6a by Hannes Mehnert
-*)
-(* edited to reflect later API (v0.9.0) changes on 2019-07-16 *)
-module Stdlib_buffer = Buffer
-open Decompress
-
-(* Keep in your mind, this is an easy example of Decompress but not efficient.
-   Don't copy/paste this code in a productive environment. *)
-
-let compress ?(level = 4) data =
-  let input_buffer = Bytes.create 0xFFFF in
-  (* We need to allocate an input buffer, the size of this buffer is important.
-     In fact, the Lz77 algorithm can find a pattern (and compress) only on this
-     input buffer. So if the input buffer is small, the algorithm has no chance
-     to find many patterns.
-
-     If it is big, the algorithm can find a far pattern and keep this pattern
-     as long as it tries to compress. The optimal size seems to be [1 << 15]
-     bytes (a bigger buffer is not necessary because the distance can be upper
-     than [1 << 15]). *)
-  let output_buffer = Bytes.create 0xFFFF in
-  (* We need to allocate an output buffer, is like you can. it's depends your
-     capabilities of your writing. *)
+let compress ?level:_ input =
+  let w = De.make_window ~bits:15 in
+  let q = De.Queue.create 0x1000 in
+  let i = Bigstringaf.create De.io_buffer_size in
+  let o = Bigstringaf.create De.io_buffer_size in
+  let b = Buffer.create 0x1000 in
   let pos = ref 0 in
-  let res = Stdlib_buffer.create (String.length data) in
-  (* The buffer is not a good idea. In fact, we can have a memory problem with
-     that (like if the output is too big). You need to keep in your mind that
-     is insecure to let a buffer to grow automatically (an attacker can use
-     this behaviour). *)
+  let refill i =
+    let len = min (Bigstringaf.length i) (String.length input - !pos) in
+    Bigstringaf.blit_from_string input ~src_off:!pos i ~dst_off:0 ~len ;
+    pos := !pos + len ; len in
+  let flush o len =
+    let str = Bigstringaf.substring o ~off:0 ~len in
+    Buffer.add_string b str in
+  Zl.Higher.compress ?level:None ~w ~q ~i ~o ~refill ~flush ;
+  Buffer.contents b
 
-  (* This is the same interface as [caml-zip]. A refiller and a flusher. The
-     refiller send you the maximum byte than you can [blit] inside the input
-     buffer.
-
-     So, if the second argument is [Some max], it's mandatory to respect that,
-     otherwise, you lost something. In the other case, you can blit the maximum
-     that what you can.
-
-     The flusher send you the output buffer and how many byte Decompress wrote
-     inside. The offset for this buffer is always [0]. Then, you need to send
-     how many bytes are free in the output buffer (and the common is that all
-     is free).
-
-     One argument (optionnal) is missing, it's the [meth]. This argument is
-     used to limit the memory used by the state internally. In fact, Decompress
-     (and `zlib`) need to keep all of your input to calculate at the end the
-     frequencies and the dictionary. So if you want to compress a big file, may
-     be you will have a memory problem (because, all your file will be present
-     in the memory). So you can specify a method to flush the internal memory
-     (with SYNC, PARTIAL or FULL - see the documentation about that) at each
-     [n] bytes, like: ~meth:(PARTIAL, 4096) flushes the internal memory when we
-     compute 4096 bytes of your input.
-
-     If [meth] is specified, the refiller has a [Some] as the second parameter.
-     Otherwise, it is [None]. *)
-  Zlib_deflate.bytes input_buffer output_buffer
-    (fun input_buffer -> function
-      | Some max ->
-          let n = min max (min 0xFFFF (String.length data - !pos)) in
-          Bytes.blit_string data !pos input_buffer 0 n ;
-          pos := !pos + n ;
-          n
-      | None ->
-          let n = min 0xFFFF (String.length data - !pos) in
-          Bytes.blit_string data !pos input_buffer 0 n ;
-          pos := !pos + n ;
-          n )
-    (fun output_buffer len ->
-      Stdlib_buffer.add_subbytes res output_buffer 0 len ;
-      0xFFFF )
-    (Zlib_deflate.default ~witness:Buffer.bytes level)
-  (* We can specify the level of the compression, see the documentation to know
-     what we use for each level. The default is 4. *)
-  |> function
-  | Ok _ -> Stdlib_buffer.contents res
-  | Error e ->
-    Logs.err (fun m -> m "error %a while compressing" Zlib_deflate.pp_error e) ;
-    invalid_arg "cannot compress"
-
-let uncompress data =
-  let input_buffer = Bytes.create 0xFFFF in
-  (* We need to allocate an input buffer. it's depends your capabilities of
-     your reading. *)
-  let output_buffer = Bytes.create 0xFFFF in
-  (* Same as [compress]. *)
-  let window = Window.create ~crc:Window.adler32 ~witness:Buffer.bytes in
-  (* We allocate a window. We let the user to do that to reuse the window if
-     it's needed. In fact, the window is a big buffer ([size = (1 << 15)]) and
-     allocate this buffer costs.
-
-     So in this case, we decompress only one time but if you want to decompress
-     some flows, you can reuse this window after a [Window.reset]. *)
+let uncompress input =
+  let w = De.make_window ~bits:15 in
+  let allocate _ = w in
+  let i = Bigstringaf.create De.io_buffer_size in
+  let o = Bigstringaf.create De.io_buffer_size in
+  let b = Buffer.create 0x1000 in
   let pos = ref 0 in
-  let res = Stdlib_buffer.create (String.length data) in
-  Zlib_inflate.bytes input_buffer output_buffer
-    (* Same logic as [compress]. *)
-      (fun input_buffer ->
-      let n = min 0xFFFF (String.length data - !pos) in
-      Bytes.blit_string data !pos input_buffer 0 n ;
-      pos := !pos + n ;
-      n )
-    (fun output_buffer len ->
-      Stdlib_buffer.add_subbytes res output_buffer 0 len ;
-      0xFFFF )
-    (Zlib_inflate.default ~witness:Buffer.bytes window)
-  |> function
-  | Ok _ -> Ok (Stdlib_buffer.contents res)
-  | Error exn ->
-    Logs.err (fun m -> m "error %a while uncompressing" Zlib_inflate.pp_error exn) ;
+  let refill i =
+    let len = min (Bigstringaf.length i) (String.length input - !pos) in
+    Bigstringaf.blit_from_string input ~src_off:!pos i ~dst_off:0 ~len ;
+    pos := !pos + len ; len in
+  let flush o len =
+    let str = Bigstringaf.substring o ~off:0 ~len in
+    Buffer.add_string b str in
+  match Zl.Higher.uncompress ~allocate ~i ~o ~refill ~flush with
+  | Ok () -> Ok (Buffer.contents b)
+  | Error (`Msg err) ->
+    Logs.err (fun m -> m "error while uncompressing: %s" err) ;
     Error ()


### PR DESCRIPTION
Due to the release of `git.3.0.0` which includes the new version of `decompress`, it could be interesting to upgrade `albatross` to the last vesion of `decompress` (`>= 1.0.0`).