### PR TITLE
Upgrade albatross to decompress.1.3.0

### DIFF
--- a/albatross.opam
+++ b/albatross.opam
@@ -30,7 +30,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "asn1-combinators" {>= "0.2.0"}
   "duration"
-  "decompress" {>= "1.2.0" & < "1.3.0"}
+  "decompress" {>= "1.3.0"}
   "bigstringaf"
   "checkseum"
   "metrics" {>= "0.2.0"}

--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -202,7 +202,7 @@ let opt_vm_name =
   Arg.(value & opt vm_c Name.root & info [ "n" ; "name"] ~doc)
 
 let compress_level default =
-  let doc = "Compression level (0 for no compression, 1-3 fixed with static huffman, 4-9 dynamic with canonic huffman)" in
+  let doc = "Compression level (0 - 9), a higher value results in smaller data, but uses more CPU " in
   Arg.(value & opt int default & info [ "compression-level" ] ~doc)
 
 let force =

--- a/src/vmm_compress.ml
+++ b/src/vmm_compress.ml
@@ -1,5 +1,5 @@
-let compress ?level:_ input =
-  let w = De.make_window ~bits:15 in
+let compress ?(level= 4) input =
+  let w = De.Lz77.make_window ~bits:15 in
   let q = De.Queue.create 0x1000 in
   let i = Bigstringaf.create De.io_buffer_size in
   let o = Bigstringaf.create De.io_buffer_size in
@@ -12,7 +12,7 @@ let compress ?level:_ input =
   let flush o len =
     let str = Bigstringaf.substring o ~off:0 ~len in
     Buffer.add_string b str in
-  Zl.Higher.compress ?level:None ~w ~q ~i ~o ~refill ~flush ;
+  Zl.Higher.compress ~level ~w ~q ~refill ~flush i o ;
   Buffer.contents b
 
 let uncompress input =
@@ -29,7 +29,7 @@ let uncompress input =
   let flush o len =
     let str = Bigstringaf.substring o ~off:0 ~len in
     Buffer.add_string b str in
-  match Zl.Higher.uncompress ~allocate ~i ~o ~refill ~flush with
+  match Zl.Higher.uncompress ~allocate ~refill ~flush i o with
   | Ok () -> Ok (Buffer.contents b)
   | Error (`Msg err) ->
     Logs.err (fun m -> m "error while uncompressing: %s" err) ;


### PR DESCRIPTION
Minor update to `decompress.1.3.0`. The format does not change and the compression ratio is better (see https://github.com/mirage/decompress/pull/108).