### PR TITLE
Adapt to x509 0.13.0 API changes

### DIFF
--- a/albatross.opam
+++ b/albatross.opam
@@ -23,8 +23,8 @@ depends: [
   "fmt"
   "astring"
   "jsonm"
-  "x509" {>= "0.11.0"}
-  "tls" {>= "0.12.2"}
+  "x509" {>= "0.13.0"}
+  "tls" {>= "0.13.1"}
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-rng" {>= "0.8.0"}

--- a/provision/albatross_provision_ca.ml
+++ b/provision/albatross_provision_ca.ml
@@ -75,13 +75,13 @@ let help _ man_format cmds = function
 
 let generate _ name db days sname sdays =
   Mirage_crypto_rng_unix.initialize () ;
-  priv_key ~bits:4096 None name >>= fun key ->
+  priv_key ~bits:4096 name >>= fun key ->
   let name = [ Distinguished_name.(Relative_distinguished_name.singleton (CN name)) ] in
-  let csr = Signing_request.create name key in
+  Signing_request.create name key >>= fun csr ->
   sign ~certname:"cacert" (d_exts ()) name key csr (Duration.of_day days) >>= fun () ->
-  priv_key None sname >>= fun skey ->
+  priv_key sname >>= fun skey ->
   let sname = [ Distinguished_name.(Relative_distinguished_name.singleton (CN sname)) ] in
-  let csr = Signing_request.create sname skey in
+  Signing_request.create sname skey >>= fun csr ->
   sign ~dbname:(Fpath.v db) s_exts name key csr (Duration.of_day sdays)
 
 open Cmdliner

--- a/provision/albatross_provision_request.ml
+++ b/provision/albatross_provision_request.ml
@@ -18,8 +18,8 @@ let csr priv name cmd =
 let jump id cmd =
   Mirage_crypto_rng_unix.initialize () ;
   let name = Vmm_core.Name.to_string id in
-  priv_key None name >>= fun priv ->
-  let csr = csr priv name cmd in
+  priv_key name >>= fun priv ->
+  csr priv name cmd >>= fun csr ->
   let enc = X509.Signing_request.encode_pem csr in
   Bos.OS.File.write Fpath.(v name + ".req") (Cstruct.to_string enc)
 

--- a/tls/albatross_tls_common.ml
+++ b/tls/albatross_tls_common.ml
@@ -38,8 +38,8 @@ let process fd =
 
 let handle tls =
   match Tls_lwt.Unix.epoch tls with
-  | `Error -> Lwt.fail_with "error while getting epoch"
-  | `Ok epoch ->
+  | Error () -> Lwt.fail_with "error while getting epoch"
+  | Ok epoch ->
     match Vmm_tls.handle epoch.Tls.Core.peer_certificate_chain with
     | Error `Msg msg ->
       Logs.err (fun m -> m "failed to handle TLS connection %s" msg);


### PR DESCRIPTION
this is the minimal set of changes for x509 0.13 (and tls 0.13). this also opens the possibility for elliptic curve certificates.