### PR TITLE
use metrics-rusage (in Albatross_cli.init_influx) to track system resource usae

### DIFF
--- a/albatross.opam
+++ b/albatross.opam
@@ -36,6 +36,7 @@ depends: [
   "metrics" {>= "0.2.0"}
   "metrics-lwt" {>= "0.2.0"}
   "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
   "hex"
 ]
 build: [

--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -15,6 +15,8 @@ let init_influx name data =
     Logs.info (fun m -> m "stats connecting to %a:%d" Ipaddr.V4.pp ip port);
     Metrics.enable_all ();
     Metrics_lwt.init_periodic (fun () -> Lwt_unix.sleep 10.);
+    Metrics_lwt.periodically (Metrics_rusage.rusage_src ~tags:[]);
+    Metrics_lwt.periodically (Metrics_rusage.kinfo_mem_src ~tags:[]);
     let get_cache, reporter = Metrics.cache_reporter () in
     Metrics.set_reporter reporter;
     let fd = ref None in

--- a/command-line/dune
+++ b/command-line/dune
@@ -3,4 +3,4 @@
   (public_name albatross.cli)
   (wrapped false)
   (modules albatross_cli)
-  (libraries checkseum.c albatross lwt.unix cmdliner logs.fmt logs.cli fmt fmt.cli fmt.tty ipaddr.unix metrics metrics-lwt metrics-influx))
+  (libraries checkseum.c albatross lwt.unix cmdliner logs.fmt logs.cli fmt fmt.cli fmt.tty ipaddr.unix metrics metrics-lwt metrics-influx metrics-rusage))


### PR DESCRIPTION
via getrusage and sysctl kern.proc.pid