### PR TITLE
FreeBSD packaging: use dune's builtin watermarking (%%VERSION_NUM%%)

### DIFF
--- a/packaging/FreeBSD/MANIFEST
+++ b/packaging/FreeBSD/MANIFEST
@@ -1,5 +1,5 @@
 name:         albatross
-version:      1.0.%%GITVER%%_1
+version:      %%VERSION_NUM%%
 origin:	      local/albatross
 comment:      Albatross: orchestrate and manage MirageOS unikernels with Solo5
 www:	      https://github.com/roburio/albatross

--- a/packaging/FreeBSD/create_package.sh
+++ b/packaging/FreeBSD/create_package.sh
@@ -48,10 +48,7 @@ do install -U $bdir/$f $sbindir/$f; done
 flatsize=$(find "$rootdir" -type f -exec stat -f %z {} + |
                awk 'BEGIN {s=0} {s+=$1} END {print s}')
 
-gitver=$(git rev-parse --short HEAD)
-
-sed -e "s:%%GITVER%%:${gitver}:" -e "s:%%FLATSIZE%%:${flatsize}:" \
-    "$pdir/MANIFEST" > "$manifest"
+sed -e "s:%%FLATSIZE%%:${flatsize}:" "$pdir/MANIFEST" > "$manifest"
 
 {
     printf '\nfiles {\n'


### PR DESCRIPTION
Instead of using a custom one. The advantage is that a release tarball will
have the release version in there, git versions will embed the latest tag and
commit.