### PR TITLE
Add albatross user and allow user into the group to use albatross

### DIFF
--- a/packaging/Linux/albatross_console.socket
+++ b/packaging/Linux/albatross_console.socket
@@ -5,7 +5,7 @@ PartOf=albatross_console.service
 [Socket]
 ListenStream=%t/albatross/util/console.sock
 SocketUser=albatross
-SocketMode=0600
+SocketMode=0660
 Accept=no
 
 [Install]

--- a/packaging/Linux/albatross_daemon.socket
+++ b/packaging/Linux/albatross_daemon.socket
@@ -4,7 +4,7 @@ PartOf=albatross_daemon.service
 
 [Socket]
 ListenStream=%t/albatross/util/vmmd.sock
-SocketMode=0600
+SocketMode=0660
 Accept=no
 
 [Install]

--- a/packaging/Linux/albatross_stats.socket
+++ b/packaging/Linux/albatross_stats.socket
@@ -5,7 +5,7 @@ PartOf=albatross_stats.service
 [Socket]
 ListenStream=%t/albatross/util/stat.sock
 SocketUser=albatross
-SocketMode=0600
+SocketMode=0660
 Accept=no
 
 [Install]

--- a/packaging/Linux/install.sh
+++ b/packaging/Linux/install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 ALBATROSS_USER=albatross
 
+useradd $ALBATROSS_USER
 sudo mkdir -m 0700 -p /var/lib/albatross/block
 
 sudo cp ../../_build/install/default/bin/* /usr/local/sbin/


### PR DESCRIPTION
It's a small improvement but when we want to install albatross, my configuration is like:
- I have an user `mirage`
- The script should create the `albatross` user
- `mirage` can be a part of the `albatross` group
- `mirage` should be allowed to use _sockets_

This patch allows the `albatross` group to use _sockets_ and create the required `albatross` user for the installation. In the opposite, the daemon fall back as a `root` user and _sockets_ got permissions only for the `root` user.