### PR TITLE
Allow any from the albatross group to manipulate the vmmd.sock

### DIFF
--- a/packaging/Linux/albatross_daemon.socket
+++ b/packaging/Linux/albatross_daemon.socket
@@ -4,6 +4,7 @@ PartOf=albatross_daemon.service
 
 [Socket]
 ListenStream=%t/albatross/util/vmmd.sock
+SocketGroup=albatross
 SocketMode=0660
 Accept=no
 


### PR DESCRIPTION
Close #79, it permits to use `albatross-client-local` with an user which is not `root` but it is a part of the `albatross` group.