### PR TITLE
Add a way to create a block device from a file

### DIFF
--- a/client/albatross_client_bistro.ml
+++ b/client/albatross_client_bistro.ml
@@ -138,8 +138,8 @@ let stats _ endp cert key ca name =
 let block_info _ endp cert key ca block_name =
   jump endp cert key ca block_name (`Block_cmd `Block_info)
 
-let block_create _ endp cert key ca block_name block_size =
-  jump endp cert key ca block_name (`Block_cmd (`Block_add block_size))
+let block_create _ endp cert key ca block_name block_src block_size =
+  jump endp cert key ca block_name (`Block_cmd (`Block_add (block_src, block_size)))
 
 let block_destroy _ endp cert key ca block_name =
   jump endp cert key ca block_name (`Block_cmd `Block_remove)
@@ -269,7 +269,7 @@ let block_create_cmd =
     [`S "DESCRIPTION";
      `P "Creation of a block device."]
   in
-  Term.(const block_create $ setup_log $ destination $ ca_cert $ ca_key $ server_ca $ block_name $ block_size),
+  Term.(const block_create $ setup_log $ destination $ ca_cert $ ca_key $ server_ca $ block_name $ block_source $ block_size),
   Term.info "create_block" ~doc ~man ~exits
 
 let block_destroy_cmd =

--- a/client/albatross_client_bistro.ml
+++ b/client/albatross_client_bistro.ml
@@ -139,6 +139,11 @@ let block_info _ endp cert key ca block_name =
   jump endp cert key ca block_name (`Block_cmd `Block_info)
 
 let block_create _ endp cert key ca block_name block_src block_size =
+  let block_src = match block_src with
+    | Some fpath ->
+      let cs = Rresult.(R.get_ok (Bos.OS.File.read fpath >>| Cstruct.of_string)) in
+      Some cs
+    | None -> None in
   jump endp cert key ca block_name (`Block_cmd (`Block_add (block_src, block_size)))
 
 let block_destroy _ endp cert key ca block_name =

--- a/client/albatross_client_local.ml
+++ b/client/albatross_client_local.ml
@@ -84,8 +84,8 @@ let stats_subscribe _ opt_socket name =
 let block_info _ opt_socket block_name =
   jump opt_socket block_name (`Block_cmd `Block_info)
 
-let block_create _ opt_socket block_name block_size =
-  jump opt_socket block_name (`Block_cmd (`Block_add block_size))
+let block_create _ opt_socket block_name block_src block_size =
+  jump opt_socket block_name (`Block_cmd (`Block_add (block_src, block_size)))
 
 let block_destroy _ opt_socket block_name =
   jump opt_socket block_name (`Block_cmd `Block_remove)
@@ -219,7 +219,7 @@ let block_create_cmd =
     [`S "DESCRIPTION";
      `P "Creation of a block device."]
   in
-  Term.(term_result (const block_create $ setup_log $ socket $ block_name $ block_size $ tmpdir)),
+  Term.(term_result (const block_create $ setup_log $ socket $ block_name $ block_source $ block_size $ tmpdir)),
   Term.info "create_block" ~doc ~man ~exits
 
 let block_destroy_cmd =

--- a/client/albatross_client_local.ml
+++ b/client/albatross_client_local.ml
@@ -85,6 +85,11 @@ let block_info _ opt_socket block_name =
   jump opt_socket block_name (`Block_cmd `Block_info)
 
 let block_create _ opt_socket block_name block_src block_size =
+  let block_src = match block_src with
+    | Some fpath ->
+      let cs = Rresult.(R.get_ok (Bos.OS.File.read fpath >>| Cstruct.of_string)) in
+      Some cs
+    | None -> None in
   jump opt_socket block_name (`Block_cmd (`Block_add (block_src, block_size)))
 
 let block_destroy _ opt_socket block_name =

--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -232,10 +232,12 @@ let block_name =
   Arg.(required & pos 0 (some vm_c) None & info [] ~doc ~docv:"BLOCK")
 
 let block_source =
-  let parser str = match Fpath.of_string str with
-    | Ok _ -> Ok str | Error _ as err -> err in
   let doc = "Source of the block device." in
-  Arg.(value & opt (some (conv (parser, Fmt.string))) None & info [ "src" ] ~doc ~docv:"<filename>")
+  let parser str = match Fpath.of_string str with
+    | Ok _ as v when Sys.file_exists str -> v
+    | Ok v -> Rresult.R.error_msgf "%a does not exist." Fpath.pp v
+    | Error _ as err -> err in
+  Arg.(value & opt (some (conv (parser, Fpath.pp))) None & info [ "src" ] ~doc ~docv:"<filename>")
 
 let block_size =
   let doc = "Block size in MB." in

--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -231,6 +231,12 @@ let block_name =
   let doc = "Name of block device." in
   Arg.(required & pos 0 (some vm_c) None & info [] ~doc ~docv:"BLOCK")
 
+let block_source =
+  let parser str = match Fpath.of_string str with
+    | Ok _ -> Ok str | Error _ as err -> err in
+  let doc = "Source of the block device." in
+  Arg.(value & opt (some (conv (parser, Fmt.string))) None & info [ "src" ] ~doc ~docv:"<filename>")
+
 let block_size =
   let doc = "Block size in MB." in
   Arg.(required & pos 1 (some int) None & info [] ~doc ~docv:"SIZE")

--- a/provision/albatross_provision_request.ml
+++ b/provision/albatross_provision_request.ml
@@ -55,6 +55,11 @@ let block_info _ block_name =
   jump block_name (`Block_cmd `Block_info)
 
 let block_create _ block_name block_src block_size =
+  let block_src = match block_src with
+    | Some fpath ->
+      let cs = Rresult.(R.get_ok (Bos.OS.File.read fpath >>| Cstruct.of_string)) in
+      Some cs
+    | None -> None in
   jump block_name (`Block_cmd (`Block_add (block_src, block_size)))
 
 let block_destroy _ block_name =

--- a/provision/albatross_provision_request.ml
+++ b/provision/albatross_provision_request.ml
@@ -54,8 +54,8 @@ let stats _ name =
 let block_info _ block_name =
   jump block_name (`Block_cmd `Block_info)
 
-let block_create _ block_name block_size =
-  jump block_name (`Block_cmd (`Block_add block_size))
+let block_create _ block_name block_src block_size =
+  jump block_name (`Block_cmd (`Block_add (block_src, block_size)))
 
 let block_destroy _ block_name =
   jump block_name (`Block_cmd `Block_remove)
@@ -164,7 +164,7 @@ let block_create_cmd =
     [`S "DESCRIPTION";
      `P "Creation of a block device."]
   in
-  Term.(term_result (const block_create $ setup_log $ block_name $ block_size)),
+  Term.(term_result (const block_create $ setup_log $ block_name $ block_source $ block_size)),
   Term.info "create_block" ~doc ~man
 
 let block_destroy_cmd =

--- a/src/vmm_asn.ml
+++ b/src/vmm_asn.ml
@@ -460,17 +460,17 @@ let policy_cmd =
 let block_cmd =
   let f = function
     | `C1 () -> `Block_info
-    | `C2 (src, size) -> `Block_add (src, size)
+    | `C2 (cs, size) -> `Block_add (cs, size)
     | `C3 () -> `Block_remove
   and g = function
     | `Block_info -> `C1 ()
-    | `Block_add (src, size) -> `C2 (src, size)
+    | `Block_add (cs, size) -> `C2 (cs, size)
     | `Block_remove -> `C3 ()
   in
   Asn.S.map f g @@
   Asn.S.(choice3
            (my_explicit 0 ~label:"info" null)
-           (my_explicit 1 ~label:"add" (sequence2 (optional utf8_string) (required int)))
+           (my_explicit 1 ~label:"add" (sequence2 (optional octet_string) (required int)))
            (my_explicit 2 ~label:"remove" null))
 
 let version =

--- a/src/vmm_asn.ml
+++ b/src/vmm_asn.ml
@@ -460,17 +460,17 @@ let policy_cmd =
 let block_cmd =
   let f = function
     | `C1 () -> `Block_info
-    | `C2 size -> `Block_add size
+    | `C2 (src, size) -> `Block_add (src, size)
     | `C3 () -> `Block_remove
   and g = function
     | `Block_info -> `C1 ()
-    | `Block_add size -> `C2 size
+    | `Block_add (src, size) -> `C2 (src, size)
     | `Block_remove -> `C3 ()
   in
   Asn.S.map f g @@
   Asn.S.(choice3
            (my_explicit 0 ~label:"info" null)
-           (my_explicit 1 ~label:"add" int)
+           (my_explicit 1 ~label:"add" (sequence2 (optional utf8_string) (required int)))
            (my_explicit 2 ~label:"remove" null))
 
 let version =

--- a/src/vmm_commands.ml
+++ b/src/vmm_commands.ml
@@ -81,14 +81,14 @@ let pp_policy_cmd ppf = function
 
 type block_cmd = [
   | `Block_info
-  | `Block_add of string option * int
+  | `Block_add of Cstruct.t option * int
   | `Block_remove
 ]
 
 let pp_block_cmd ppf = function
   | `Block_info -> Fmt.string ppf "block info"
   | `Block_add (None, size) -> Fmt.pf ppf "block add %d" size
-  | `Block_add (Some src, size) -> Fmt.pf ppf "block add --src %s %d" src size
+  | `Block_add (Some _, size) -> Fmt.pf ppf "block add --src <filename> %d" size
   | `Block_remove -> Fmt.string ppf "block remove"
 
 type t = [

--- a/src/vmm_commands.ml
+++ b/src/vmm_commands.ml
@@ -81,13 +81,14 @@ let pp_policy_cmd ppf = function
 
 type block_cmd = [
   | `Block_info
-  | `Block_add of int
+  | `Block_add of string option * int
   | `Block_remove
 ]
 
 let pp_block_cmd ppf = function
   | `Block_info -> Fmt.string ppf "block info"
-  | `Block_add size -> Fmt.pf ppf "block add %d" size
+  | `Block_add (None, size) -> Fmt.pf ppf "block add %d" size
+  | `Block_add (Some src, size) -> Fmt.pf ppf "block add --src %s %d" src size
   | `Block_remove -> Fmt.string ppf "block remove"
 
 type t = [

--- a/src/vmm_commands.mli
+++ b/src/vmm_commands.mli
@@ -44,7 +44,7 @@ type policy_cmd = [
 
 type block_cmd = [
   | `Block_info
-  | `Block_add of string option * int
+  | `Block_add of Cstruct.t option * int
   | `Block_remove
 ]
 

--- a/src/vmm_commands.mli
+++ b/src/vmm_commands.mli
@@ -44,7 +44,7 @@ type policy_cmd = [
 
 type block_cmd = [
   | `Block_info
-  | `Block_add of int
+  | `Block_add of string option * int
   | `Block_remove
 ]
 

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -389,7 +389,7 @@ let create_block name src size =
     | None -> R.ok ()
     | Some src ->
       Fpath.of_string src |> R.open_error_msg >>= fun src ->
-      Bos.OS.Path.must_exist src >>= fun src ->
+      Bos.OS.File.must_exist src >>= fun src ->
       let size'' = (Unix.stat (Fpath.to_string src)).Unix.st_size in
       if size'' > size'
       then R.error_msgf "%a is too big to be save as a block device." Fpath.pp src

--- a/src/vmm_unix.mli
+++ b/src/vmm_unix.mli
@@ -26,7 +26,7 @@ val destroy : Unikernel.t -> unit
 
 val close_no_err : Unix.file_descr -> unit
 
-val create_block : Name.t -> string option -> int -> (unit, [> R.msg ]) result
+val create_block : Name.t -> Cstruct.t option -> int -> (unit, [> R.msg ]) result
 
 val destroy_block : Name.t -> (unit, [> R.msg ]) result
 

--- a/src/vmm_unix.mli
+++ b/src/vmm_unix.mli
@@ -26,7 +26,7 @@ val destroy : Unikernel.t -> unit
 
 val close_no_err : Unix.file_descr -> unit
 
-val create_block : Name.t -> int -> (unit, [> R.msg ]) result
+val create_block : Name.t -> string option -> int -> (unit, [> R.msg ]) result
 
 val destroy_block : Name.t -> (unit, [> R.msg ]) result
 

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -330,14 +330,14 @@ let handle_block_cmd t id = function
         Vmm_resources.remove_block t.resources id >>= fun resources ->
         Ok ({ t with resources }, `End (`Success (`String "removed block")))
     end
-  | `Block_add size ->
+  | `Block_add (src, size) ->
     begin
       Logs.debug (fun m -> m "insert block %a: %dMB" Name.pp id size) ;
       match Vmm_resources.find_block t.resources id with
       | Some _ -> Error (`Msg "block device with same name already exists")
       | None ->
         Vmm_resources.check_block t.resources id size >>= fun () ->
-        Vmm_unix.create_block id size >>= fun () ->
+        Vmm_unix.create_block id src size >>= fun () ->
         Vmm_resources.insert_block t.resources id size >>= fun resources ->
         Ok ({ t with resources }, `End (`Success (`String "added block device")))
     end

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -330,14 +330,14 @@ let handle_block_cmd t id = function
         Vmm_resources.remove_block t.resources id >>= fun resources ->
         Ok ({ t with resources }, `End (`Success (`String "removed block")))
     end
-  | `Block_add (src, size) ->
+  | `Block_add (cs, size) ->
     begin
       Logs.debug (fun m -> m "insert block %a: %dMB" Name.pp id size) ;
       match Vmm_resources.find_block t.resources id with
       | Some _ -> Error (`Msg "block device with same name already exists")
       | None ->
         Vmm_resources.check_block t.resources id size >>= fun () ->
-        Vmm_unix.create_block id src size >>= fun () ->
+        Vmm_unix.create_block id cs size >>= fun () ->
         Vmm_resources.insert_block t.resources id size >>= fun resources ->
         Ok ({ t with resources }, `End (`Success (`String "added block device")))
     end


### PR DESCRIPTION
Currently, it's not possible to create a new block device from a file - and then, use it for many unikernels. This is a fast patch, I don't really if it's the right way to implement it, but, at least, it compiles.