### PR TITLE
Further changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,21 @@
+# v1.3.0 (2021-09-??)
+
+- provide arguments for public-key-type and bits, the default is now
+  Ed25519 (used to be RSA) (@hannesm)
+- use happy-eyeballs for name resolution and connection setup (@hannesm)
+- converge albatross-client-* semantics (@hannesm)
+- Implement block_set and block_dump subcommands, also block_add is extended
+  to include the block device data (@hannesm, inspired by @dinosaure)
+- Implement update subcommand for albatross-client-{local,bistro}, which
+  (a) retrieves the digest of a running unikernel (b) looks up that hash
+  on http://builds.robur.coop (a repository of reproducible built unikernels)
+  (c) does a unikernel update (with same arguments and configuration)
+  (@reynir @hannesm)
+- Debian and FreeBSD packaging via orb, available on https://builds.robur.coop
+  (#80 @hannesm @reynir)
+- Linux: add albatross user and group, as done on FreeBSD (#79 #81 @dinosaure)
+- Fixes to README (#78 @yomimono)
+
 # v1.2.0 (2021-06-08)
 
 - linux packaging albatross_stat -> albatross_stats (#73 @smorimoto)

--- a/albatross.opam
+++ b/albatross.opam
@@ -26,7 +26,6 @@ depends: [
   "x509" {>= "0.13.0"}
   "tls" {>= "0.13.1"}
   "mirage-crypto"
-  "mirage-crypto-pk"
   "mirage-crypto-rng" {>= "0.8.0"}
   "asn1-combinators" {>= "0.2.0"}
   "duration"

--- a/albatross.opam
+++ b/albatross.opam
@@ -38,7 +38,8 @@ depends: [
   "metrics-influx" {>= "0.2.0"}
   "metrics-rusage"
   "hex"
-  "http-lwt-client" {>= "0.0.3"}
+  "http-lwt-client" {>= "0.0.4"}
+  "happy-eyeballs-lwt"
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/client/albatross_client_bistro.ml
+++ b/client/albatross_client_bistro.ml
@@ -85,10 +85,7 @@ let connect ?(happy_eyeballs = Happy_eyeballs_lwt.create ()) (host, port) cert k
           Lwt.return (Error Albatross_cli.Connect_failed)
         | Ok ((ip, port), fd) ->
           Logs.debug (fun m -> m "connected to remote host %a:%d" Ipaddr.pp ip port) ;
-          (* reneg true to allow re-negotiation over the server-authenticated TLS
-             channel (to transport client certificate encrypted), once TLS 1.3 is in
-             (and required) be removed! *)
-          let client = Tls.Config.client ~reneg:true ~certificates ~authenticator () in
+          let client = Tls.Config.client ~certificates ~authenticator () in
           Lwt.catch (fun () ->
               Tls_lwt.Unix.client_of_fd client (* TODO ~host *) fd >|= fun fd ->
               Logs.debug (fun m -> m "finished tls handshake") ;

--- a/client/albatross_client_local.ml
+++ b/client/albatross_client_local.ml
@@ -114,10 +114,11 @@ let update _ opt_socket host dryrun level name tmpdir =
   let open Lwt_result.Infix in
   Albatross_cli.set_tmpdir tmpdir;
   Lwt_main.run (
+    let happy_eyeballs = Happy_eyeballs_lwt.create () in
     connect opt_socket name (`Unikernel_cmd `Unikernel_info) >>= fun (fd, _next) ->
     Lwt_result.ok (Vmm_lwt.read_wire fd) >>= fun r ->
     Lwt_result.ok (Vmm_lwt.safe_close fd) >>= fun () ->
-    Albatross_client_update.prepare_update level host dryrun r >>= fun cmd ->
+    Albatross_client_update.prepare_update ~happy_eyeballs level host dryrun r >>= fun cmd ->
     connect opt_socket name (`Unikernel_cmd cmd) >>= fun (fd, _next) ->
     Lwt_result.ok (Vmm_lwt.read_wire fd) >>= fun r ->
     Lwt_result.ok (Vmm_lwt.safe_close fd) >>= fun () ->

--- a/client/albatross_client_remote_tls.ml
+++ b/client/albatross_client_remote_tls.ml
@@ -30,7 +30,7 @@ let client cas host port cert priv_key =
       | Ok (_, fd) ->
         X509_lwt.private_of_pems ~cert ~priv_key >>= fun cert ->
         let certificates = `Single cert in
-        let client = Tls.Config.client ~reneg:true ~certificates ~authenticator () in
+        let client = Tls.Config.client ~certificates ~authenticator () in
         Tls_lwt.Unix.client_of_fd client (* ~host *) fd >>= fun t ->
         let next = match Vmm_tls.wire_command_of_cert (List.hd (fst cert)) with
           | Ok (_, cmd) -> snd (Vmm_commands.endpoint cmd)

--- a/client/dune
+++ b/client/dune
@@ -3,21 +3,21 @@
   (public_name albatross-client-bistro)
   (package albatross)
   (modules albatross_client_bistro)
-  (libraries albatross.cli albatross albatross.tls albatross_tls_cli albatross_client_update))
+  (libraries albatross.cli albatross albatross.tls albatross_tls_cli albatross_client_update happy-eyeballs-lwt))
 
 (executable
   (name albatross_client_local)
   (public_name albatross-client-local)
   (package albatross)
   (modules albatross_client_local)
-  (libraries albatross.cli albatross albatross_client_update))
+  (libraries albatross.cli albatross albatross_client_update happy-eyeballs-lwt))
 
 (executable
   (name albatross_client_remote_tls)
   (public_name albatross-client-remote-tls)
   (package albatross)
   (modules albatross_client_remote_tls)
-  (libraries albatross.cli albatross albatross.tls albatross_tls_cli))
+  (libraries albatross.cli albatross albatross.tls albatross_tls_cli happy-eyeballs-lwt))
 
 (executable
   (name albatross_client_inspect_dump)

--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -415,6 +415,14 @@ let systemd_socket_activation =
     let doc = "Pass this flag when systemd socket activation is being used" in
     Arg.(value & flag & info [ "systemd-socket-activation" ] ~doc)
 
+let pub_key_type =
+  let doc = "Asymmetric key type to use" in
+  Arg.(value & opt (Arg.enum X509.Key_type.strings) `ED25519 & info [ "key-type" ] ~doc)
+
+let key_bits =
+  let doc = "Public key bits to use (only relevant for RSA)" in
+  Arg.(value & opt int 4096 & info [ "bits" ] ~doc)
+
 let exit_status = function
   | Ok () -> Ok Success
   | Error e -> Ok e

--- a/command-line/albatross_client_update.ml
+++ b/command-line/albatross_client_update.ml
@@ -5,8 +5,8 @@ let job_and_build loc =
   | "" :: "job" :: jobname :: "build" :: uuid :: "" :: [] -> Ok (jobname, uuid)
   | _ -> Error (`Msg ("expected '/job/<jobname>/build/<uuid>', got: " ^ loc))
 
-let http_get_redirect uri =
-  Http_lwt_client.one_request ~follow_redirect:false uri >|= function
+let http_get_redirect ~happy_eyeballs uri =
+  Http_lwt_client.one_request ~happy_eyeballs ~follow_redirect:false uri >|= function
   | Error _ as e -> e
   | Ok (resp, _body) ->
     match resp.Http_lwt_client.status with
@@ -18,23 +18,23 @@ let http_get_redirect uri =
       Logs.warn (fun m -> m "received HTTP reply: %a" Http_lwt_client.pp_response resp);
       Error (`Msg "unexpected HTTP reply")
 
-let retrieve_build host hash =
+let retrieve_build ~happy_eyeballs host hash =
    let uri = host ^ "/hash?sha256=" ^ hash in
-   Lwt_result.bind_result (http_get_redirect uri) job_and_build
+   Lwt_result.bind_result (http_get_redirect ~happy_eyeballs uri) job_and_build
 
-let retrieve_latest_build host jobname =
+let retrieve_latest_build ~happy_eyeballs host jobname =
   let uri = host ^ "/job/" ^ jobname ^ "/build/latest/" in
-  Lwt_result.bind_result (http_get_redirect uri) job_and_build
+  Lwt_result.bind_result (http_get_redirect ~happy_eyeballs uri) job_and_build
 
-let can_update host hash =
+let can_update ~happy_eyeballs host hash =
   let open Lwt_result.Infix in
-  retrieve_build host hash >>= fun (job, build) ->
-  retrieve_latest_build host job >|= fun (_, build') ->
+  retrieve_build ~happy_eyeballs host hash >>= fun (job, build) ->
+  retrieve_latest_build ~happy_eyeballs host job >|= fun (_, build') ->
   job, build, build'
 
-let http_get_binary host job build =
+let http_get_binary ~happy_eyeballs host job build =
   let uri = host ^ "/job/" ^ job ^ "/build/" ^ build ^ "/main-binary" in
-  Http_lwt_client.one_request uri >|= function
+  Http_lwt_client.one_request ~happy_eyeballs uri >|= function
   | Error _ as e -> e
   | Ok (resp, None) ->
     Logs.warn (fun m -> m "received HTTP reply without body: %a" Http_lwt_client.pp_response resp);
@@ -46,12 +46,12 @@ let http_get_binary host job build =
       Logs.warn (fun m -> m "received HTTP reply: %a" Http_lwt_client.pp_response resp);
       Error (`Msg "unexpected HTTP reply")
 
-let prepare_update level host dryrun = function
+let prepare_update ~happy_eyeballs level host dryrun = function
   | Ok (_hdr, `Success (`Unikernel_info
       [ _name, Vmm_core.Unikernel.{ digest ; bridges ; block_devices ; argv ; cpuid ; memory ; fail_behaviour ; typ = `Solo5 as typ ; _ } ])) ->
     begin
       let `Hex hash = Hex.of_cstruct digest in
-      can_update host hash >>= function
+      can_update ~happy_eyeballs host hash >>= function
       | Error `Msg msg ->
         Logs.err (fun m -> m "error in HTTP interaction: %s" msg);
         Lwt.return (Error Albatross_cli.Http_error)
@@ -65,7 +65,7 @@ let prepare_update level host dryrun = function
       | Ok (job, old_uuid, new_uuid) ->
         Logs.app (fun m -> m "compare at %s/compare/%s/%s/opam-switch"
                      host old_uuid new_uuid);
-        http_get_binary host job new_uuid >>= function
+        http_get_binary ~happy_eyeballs host job new_uuid >>= function
         | Error `Msg msg ->
           Logs.err (fun m -> m "error in HTTP interaction: %s" msg);
           Lwt.return (Error Albatross_cli.Http_error)

--- a/command-line/dune
+++ b/command-line/dune
@@ -3,7 +3,7 @@
   (public_name albatross.cli)
   (wrapped false)
   (modules albatross_cli)
-  (libraries checkseum.c albatross lwt.unix cmdliner logs.fmt logs.cli fmt fmt.cli fmt.tty ipaddr.unix metrics metrics-lwt metrics-influx metrics-rusage))
+  (libraries checkseum.c albatross lwt.unix cmdliner logs.fmt logs.cli fmt fmt.cli fmt.tty ipaddr.unix metrics metrics-lwt metrics-influx metrics-rusage x509))
 
 (library
   (name albatross_client_update)

--- a/provision/albatross_provision_request.ml
+++ b/provision/albatross_provision_request.ml
@@ -15,64 +15,68 @@ let csr priv name cmd =
   let extensions = X509.Signing_request.Ext.(singleton Extensions ext) in
   X509.Signing_request.create name ~extensions priv
 
-let jump id cmd =
+let jump key_type bits id cmd =
   Mirage_crypto_rng_unix.initialize () ;
   let name = Vmm_core.Name.to_string id in
-  priv_key name >>= fun priv ->
+  priv_key key_type bits name >>= fun priv ->
   csr priv name cmd >>= fun csr ->
   let enc = X509.Signing_request.encode_pem csr in
   Bos.OS.File.write Fpath.(v name + ".req") (Cstruct.to_string enc)
 
-let info_policy _ name =
-  jump name (`Policy_cmd `Policy_info)
+let info_policy _ key_type bits name =
+  jump key_type bits name (`Policy_cmd `Policy_info)
 
-let remove_policy _ name =
-  jump name (`Policy_cmd `Policy_remove)
+let remove_policy _ key_type bits name =
+  jump key_type bits name (`Policy_cmd `Policy_remove)
 
-let add_policy _ name vms memory cpus block bridges =
+let add_policy _ key_type bits name vms memory cpus block bridges =
   let p = Albatross_cli.policy vms memory cpus block bridges in
-  jump name (`Policy_cmd (`Policy_add p))
+  jump key_type bits name (`Policy_cmd (`Policy_add p))
 
-let info_ _ name = jump name (`Unikernel_cmd `Unikernel_info)
+let info_ _ key_type bits name =
+  jump key_type bits name (`Unikernel_cmd `Unikernel_info)
 
-let get _ name compression = jump name (`Unikernel_cmd (`Unikernel_get compression))
+let get _ key_type bits name compression =
+  jump key_type bits name (`Unikernel_cmd (`Unikernel_get compression))
 
-let destroy _ name =
-  jump name (`Unikernel_cmd `Unikernel_destroy)
+let destroy _ key_type bits name =
+  jump key_type bits name (`Unikernel_cmd `Unikernel_destroy)
 
-let create _ force name image cpuid memory argv block network compression restart_on_fail exit_code =
+let create _ key_type bits name force image cpuid memory argv block network compression restart_on_fail exit_code =
   match Albatross_cli.create_vm force image cpuid memory argv block network compression restart_on_fail exit_code with
-  | Ok cmd -> jump name (`Unikernel_cmd cmd)
+  | Ok cmd -> jump key_type bits name (`Unikernel_cmd cmd)
   | Error (`Msg msg) -> Error (`Msg msg)
 
-let console _ name since count =
-  jump name (`Console_cmd (`Console_subscribe (Albatross_cli.since_count since count)))
+let console _ key_type bits name since count =
+  let cmd = `Console_subscribe (Albatross_cli.since_count since count) in
+  jump key_type bits name (`Console_cmd cmd)
 
-let stats _ name =
-  jump name (`Stats_cmd `Stats_subscribe)
+let stats _ key_type bits name =
+  jump key_type bits name (`Stats_cmd `Stats_subscribe)
 
-let block_info _ block_name =
-  jump block_name (`Block_cmd `Block_info)
+let block_info _ key_type bits block_name =
+  jump key_type bits block_name (`Block_cmd `Block_info)
 
-let block_dump _ block_name compression =
-  jump block_name (`Block_cmd (`Block_dump compression))
 
-let block_create _ block_name block_size compression block_data =
+let block_dump _ key_type bits block_name compression =
+  jump key_type bits block_name (`Block_cmd (`Block_dump compression))
+
+let block_create _ key_type bits block_name block_size compression block_data =
   match Albatross_cli.create_block block_size compression block_data with
   | Error (`Msg msg) -> failwith msg
-  | Ok cmd -> jump block_name (`Block_cmd cmd)
+  | Ok cmd -> jump key_type bits block_name (`Block_cmd cmd)
 
-let block_set _ block_name compression block_data =
+let block_set _ key_type bits block_name compression block_data =
   let compressed, data =
     if compression > 0 then
       true, Vmm_compress.compress_cs compression block_data
     else
       false, block_data
   in
-  jump block_name (`Block_cmd (`Block_set (compressed, data)))
+  jump key_type bits block_name (`Block_cmd (`Block_set (compressed, data)))
 
-let block_destroy _ block_name =
-  jump block_name (`Block_cmd `Block_remove)
+let block_destroy _ key_type bits block_name =
+  jump key_type bits block_name (`Block_cmd `Block_remove)
 
 let help _ man_format cmds = function
   | None -> `Help (`Pager, None)
@@ -88,7 +92,7 @@ let destroy_cmd =
     [`S "DESCRIPTION";
      `P "Destroy a virtual machine."]
   in
-  Term.(term_result (const destroy $ setup_log $ vm_name)),
+  Term.(term_result (const destroy $ setup_log $ pub_key_type $ key_bits $ vm_name)),
   Term.info "destroy" ~doc ~man
 
 let remove_policy_cmd =
@@ -97,7 +101,7 @@ let remove_policy_cmd =
     [`S "DESCRIPTION";
      `P "Removes a policy."]
   in
-  Term.(term_result (const remove_policy $ setup_log $ opt_vm_name)),
+  Term.(term_result (const remove_policy $ setup_log $ pub_key_type $ key_bits $ opt_vm_name)),
   Term.info "remove_policy" ~doc ~man
 
 let info_cmd =
@@ -106,7 +110,7 @@ let info_cmd =
     [`S "DESCRIPTION";
      `P "Shows information about VMs."]
   in
-  Term.(term_result (const info_ $ setup_log $ opt_vm_name)),
+  Term.(term_result (const info_ $ setup_log $ pub_key_type $ key_bits $ opt_vm_name)),
   Term.info "info" ~doc ~man
 
 let get_cmd =
@@ -115,7 +119,7 @@ let get_cmd =
     [`S "DESCRIPTION";
      `P "Downloads a VM."]
   in
-  Term.(term_result (const get $ setup_log $ vm_name $ compress_level 9)),
+  Term.(term_result (const get $ setup_log $ pub_key_type $ key_bits $ vm_name $ compress_level 9)),
   Term.info "get" ~doc ~man ~exits
 
 let policy_cmd =
@@ -124,7 +128,7 @@ let policy_cmd =
     [`S "DESCRIPTION";
      `P "Shows information about policies."]
   in
-  Term.(term_result (const info_policy $ setup_log $ opt_vm_name)),
+  Term.(term_result (const info_policy $ setup_log $ pub_key_type $ key_bits $ opt_vm_name)),
   Term.info "policy" ~doc ~man
 
 let add_policy_cmd =
@@ -133,7 +137,7 @@ let add_policy_cmd =
     [`S "DESCRIPTION";
      `P "Adds a policy."]
   in
-  Term.(term_result (const add_policy $ setup_log $ vm_name $ vms $ mem $ cpus $ opt_block_size $ bridge)),
+  Term.(term_result (const add_policy $ setup_log $ pub_key_type $ key_bits $ vm_name $ vms $ mem $ cpus $ opt_block_size $ bridge)),
   Term.info "add_policy" ~doc ~man
 
 let create_cmd =
@@ -142,7 +146,7 @@ let create_cmd =
     [`S "DESCRIPTION";
      `P "Creates a virtual machine."]
   in
-  Term.(term_result (const create $ setup_log $ force $ vm_name $ image $ cpu $ vm_mem $ args $ block $ net $ compress_level 9 $ restart_on_fail $ exit_code)),
+  Term.(term_result (const create $ setup_log $ pub_key_type $ key_bits $ vm_name $ force $ image $ cpu $ vm_mem $ args $ block $ net $ compress_level 9 $ restart_on_fail $ exit_code)),
   Term.info "create" ~doc ~man
 
 let console_cmd =
@@ -151,7 +155,7 @@ let console_cmd =
     [`S "DESCRIPTION";
      `P "Shows console output of a VM."]
   in
-  Term.(term_result (const console $ setup_log $ vm_name $ since $ count)),
+  Term.(term_result (const console $ setup_log $ pub_key_type $ key_bits $ vm_name $ since $ count)),
   Term.info "console" ~doc ~man
 
 let stats_cmd =
@@ -160,7 +164,7 @@ let stats_cmd =
     [`S "DESCRIPTION";
      `P "Shows statistics of VMs."]
   in
-  Term.(term_result (const stats $ setup_log $ opt_vm_name)),
+  Term.(term_result (const stats $ setup_log $ pub_key_type $ key_bits $ opt_vm_name)),
   Term.info "stats" ~doc ~man
 
 let block_info_cmd =
@@ -169,7 +173,7 @@ let block_info_cmd =
     [`S "DESCRIPTION";
      `P "Block device information."]
   in
-  Term.(term_result (const block_info $ setup_log $ opt_block_name)),
+  Term.(term_result (const block_info $ setup_log $ pub_key_type $ key_bits $ opt_block_name)),
   Term.info "block" ~doc ~man
 
 let block_create_cmd =
@@ -178,7 +182,7 @@ let block_create_cmd =
     [`S "DESCRIPTION";
      `P "Creation of a block device."]
   in
-  Term.(term_result (const block_create $ setup_log $ block_name $ block_size $ compress_level 9 $ opt_block_data)),
+  Term.(term_result (const block_create $ setup_log $ pub_key_type $ key_bits $ block_name $ block_size $ compress_level 9 $ opt_block_data)),
   Term.info "create_block" ~doc ~man
 
 let block_set_cmd =
@@ -187,7 +191,7 @@ let block_set_cmd =
     [`S "DESCRIPTION";
      `P "Set data to a block device."]
   in
-  Term.(term_result (const block_set $ setup_log $ block_name $ compress_level 9 $ block_data)),
+  Term.(term_result (const block_set $ setup_log $ pub_key_type $ key_bits $ block_name $ compress_level 9 $ block_data)),
   Term.info "set_block" ~doc ~man ~exits
 
 let block_dump_cmd =
@@ -196,7 +200,7 @@ let block_dump_cmd =
     [`S "DESCRIPTION";
      `P "Dump data of a block device."]
   in
-  Term.(term_result (const block_dump $ setup_log $ block_name $ compress_level 9)),
+  Term.(term_result (const block_dump $ setup_log $ pub_key_type $ key_bits $ block_name $ compress_level 9)),
   Term.info "dump_block" ~doc ~man ~exits
 
 let block_destroy_cmd =
@@ -205,7 +209,7 @@ let block_destroy_cmd =
     [`S "DESCRIPTION";
      `P "Destroys a block device."]
   in
-  Term.(term_result (const block_destroy $ setup_log $ block_name)),
+  Term.(term_result (const block_destroy $ setup_log $ pub_key_type $ key_bits $ block_name)),
   Term.info "destroy_block" ~doc ~man
 
 let help_cmd =

--- a/provision/dune
+++ b/provision/dune
@@ -4,7 +4,7 @@
   (public_name albatross.provision)
   (wrapped false)
   (modules albatross_provision)
-  (libraries albatross.cli x509 mirage-crypto-pk mirage-crypto-rng.unix))
+  (libraries albatross.cli x509 mirage-crypto-rng.unix))
 
 (executable
   (name albatross_provision_ca)


### PR DESCRIPTION
this uses happy-eyeballs in remote-client-tls, bistro -- and uses http-lwt-client 0.0.4 feature to pass through the happy eyeballs state.

it is on top of #85 and once http-lwt-client is merged into opam-repository https://github.com/ocaml/opam-repository/pull/19487, this should compile (and ready to be merged & released)