### PR TITLE
by default, be less verbose when printing unikernel config and info:

### DIFF
--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -62,9 +62,10 @@ type exit_status =
   | Http_error
 
 let output_result ((hdr, reply) as wire) =
+  let verbose = match Logs.level () with Some Logs.Debug -> true | _ -> false in
   match reply with
   | `Success s ->
-    Logs.app (fun m -> m "%a" Vmm_commands.pp_wire wire);
+    Logs.app (fun m -> m "%a" (Vmm_commands.pp_wire ~verbose) wire);
     let write_to_file name compressed data =
       let filename =
         let ts = Ptime.to_rfc3339 (Ptime_clock.now ()) in
@@ -99,14 +100,14 @@ let output_result ((hdr, reply) as wire) =
     end;
     Ok ()
   | `Data _ ->
-    Logs.app (fun m -> m "%a" Vmm_commands.pp_wire wire);
+    Logs.app (fun m -> m "%a" (Vmm_commands.pp_wire ~verbose) wire);
     Ok ()
   | `Failure _ ->
-    Logs.warn (fun m -> m "%a" Vmm_commands.pp_wire wire);
+    Logs.warn (fun m -> m "%a" (Vmm_commands.pp_wire ~verbose) wire);
     Error Remote_command_failed
   | `Command _ ->
     Logs.err (fun m -> m "received unexpected command %a"
-                 Vmm_commands.pp_wire wire);
+                 (Vmm_commands.pp_wire ~verbose) wire);
     Error Internal_error
 
 let setup_log style_renderer level =

--- a/command-line/albatross_client_update.ml
+++ b/command-line/albatross_client_update.ml
@@ -87,6 +87,7 @@ let prepare_update ~happy_eyeballs level host dryrun = function
             Lwt.return (Ok (`Unikernel_force_create config))
     end
   | Ok w ->
-    Logs.err (fun m -> m "unexpected reply: %a" Vmm_commands.pp_wire w);
+    Logs.err (fun m -> m "unexpected reply: %a"
+                 (Vmm_commands.pp_wire ~verbose:false) w);
     Lwt.return (Error Albatross_cli.Communication_failed)
   | Error _ -> Lwt.return (Error Albatross_cli.Communication_failed)

--- a/daemon/albatross_console.ml
+++ b/daemon/albatross_console.ml
@@ -149,7 +149,8 @@ let handle s addr =
             Vmm_lwt.read_wire s >|= fun _ -> ()
       end
     | Ok wire ->
-      Logs.err (fun m -> m "unexpected wire %a" Vmm_commands.pp_wire wire) ;
+      Logs.err (fun m -> m "unexpected wire %a"
+                   (Vmm_commands.pp_wire ~verbose:false) wire) ;
       Lwt.return ()
   in
   loop () >>= fun () ->

--- a/daemon/albatross_influx.ml
+++ b/daemon/albatross_influx.ml
@@ -228,7 +228,8 @@ let rec read_sock_write_tcp drop c ?fd addr =
           false
       end
     | Ok wire ->
-      Logs.warn (fun m -> m "ignoring %a" Vmm_commands.pp_wire wire) ;
+      Logs.warn (fun m -> m "ignoring %a"
+                    (Vmm_commands.pp_wire ~verbose:false) wire) ;
       Lwt.return (Some fd) >>= fun fd ->
       read_sock_write_tcp drop c ?fd addr
 

--- a/daemon/albatrossd.ml
+++ b/daemon/albatrossd.ml
@@ -76,7 +76,8 @@ let handle cons_out stat_out fd addr =
         (* TODO should we terminate the connection on write failure? *)
         Vmm_lwt.write_wire fd (hdr, wire') >|= fun _ -> ()
       in
-      Logs.debug (fun m -> m "read %a" Vmm_commands.pp_wire (hdr, wire));
+      Logs.debug (fun m -> m "read %a"
+                     (Vmm_commands.pp_wire ~verbose:false) (hdr, wire));
       Lwt_mutex.lock create_lock >>= fun () ->
       match Vmm_vmmd.handle_command !state (hdr, wire) with
       | Error wire' -> Lwt_mutex.unlock create_lock; out wire'
@@ -119,7 +120,9 @@ let write_reply name fd txt (hdr, cmd) =
         invalid_arg "wrong sequence number received"
       end else begin
         Logs.debug (fun m -> m "%s: received valid reply from %s %a (request %a)"
-                       txt name Vmm_commands.pp_wire (hdr', reply) Vmm_commands.pp_wire (hdr, cmd)) ;
+                       txt name
+                       (Vmm_commands.pp_wire ~verbose:false) (hdr', reply)
+                       (Vmm_commands.pp_wire ~verbose:false) (hdr, cmd)) ;
         match reply with
         | `Success _ -> Ok ()
         | `Failure msg ->
@@ -189,7 +192,7 @@ let jump _ systemd influx tmpdir dbdir retries enable_stats =
        and stat_out txt wire = match s with
          | None ->
            Logs.info (fun m -> m "ignoring stat %s %a" txt
-                         Vmm_commands.pp_wire wire);
+                         (Vmm_commands.pp_wire ~verbose:false) wire);
            Lwt.return_unit
          | Some s -> write_reply "stat" s txt wire >|= fun _ -> ()
        in

--- a/provision/albatross_provision_ca.ml
+++ b/provision/albatross_provision_ca.ml
@@ -51,7 +51,7 @@ let sign_csr dbname cacert key csr days =
         | _ -> l_exts, 1
       in
       let days = Option.value ~default:default_days days in
-      Logs.app (fun m -> m "signing %a" Vmm_commands.pp cmd);
+      Logs.app (fun m -> m "signing %a" (Vmm_commands.pp ~verbose:false) cmd);
       (* the "false" is here since X509 validation bails on exts marked as
          critical (as required), but has no way to supply which extensions
          are actually handled by the application / caller *)

--- a/src/vmm_commands.mli
+++ b/src/vmm_commands.mli
@@ -58,7 +58,7 @@ type t = [
   | `Block_cmd of block_cmd
 ]
 
-val pp : t Fmt.t
+val pp : verbose:bool -> t Fmt.t
 
 type data = [
   | `Console_data of Ptime.t * string
@@ -95,6 +95,6 @@ type res = [
 
 type wire = header * res
 
-val pp_wire : wire Fmt.t
+val pp_wire : verbose:bool -> wire Fmt.t
 
 val endpoint : t -> service * [ `End | `Read ]

--- a/src/vmm_core.ml
+++ b/src/vmm_core.ml
@@ -222,7 +222,7 @@ module Unikernel = struct
       (List.map (fun (a, b) -> a, (match b with None -> a | Some b -> b)) xs)
 
   let pp_config ppf (vm : config) =
-    Fmt.pf ppf "typ %a@ compression %B image %d bytes@ fail behaviour %a@ cpu %d@ %d MB memory@ block devices %a@ bridge %a@ argv %a"
+    Fmt.pf ppf "typ %a@ compression %B image %d bytes@ fail behaviour %a@ cpu %d@ %d MB memory@ block devices %a@ bridge %a"
       pp_typ vm.typ
       vm.compressed
       (Cstruct.length vm.image)
@@ -230,6 +230,9 @@ module Unikernel = struct
       vm.cpuid vm.memory
       pp_opt_list vm.block_devices
       pp_opt_list vm.bridges
+
+  let pp_config_with_argv ppf (vm : config) =
+    Fmt.pf ppf "%a@ argv %a" pp_config vm
       Fmt.(option ~none:(any "no") (list ~sep:(any " ") string)) vm.argv
 
   let restart_handler config =
@@ -271,14 +274,18 @@ module Unikernel = struct
 
   let pp_info ppf (info : info) =
     let `Hex hex_digest = Hex.of_cstruct info.digest in
-    Fmt.pf ppf "typ %a@ fail behaviour %a@ cpu %d@ %d MB memory@ block devices %a@ bridge %a@ argv %a@ digest %s"
+    Fmt.pf ppf "typ %a@ fail behaviour %a@ cpu %d@ %d MB memory@ block devices %a@ bridge %a@ digest %s"
       pp_typ info.typ
       pp_fail_behaviour info.fail_behaviour
       info.cpuid info.memory
       pp_opt_list info.block_devices
       pp_opt_list info.bridges
-      Fmt.(option ~none:(any "no") (list ~sep:(any " ") string)) info.argv
       hex_digest
+
+  let pp_info_with_argv ppf (info : info) =
+    Fmt.pf ppf "%a@ argv %a"
+      pp_info info
+      Fmt.(option ~none:(any "no") (list ~sep:(any " ") string)) info.argv
 end
 
 module Stats = struct

--- a/src/vmm_core.mli
+++ b/src/vmm_core.mli
@@ -90,6 +90,8 @@ module Unikernel : sig
 
   val pp_config : config Fmt.t
 
+  val pp_config_with_argv : config Fmt.t
+
   val restart_handler : config -> bool
 
   type t = {
@@ -116,6 +118,8 @@ module Unikernel : sig
   val info : t -> info
 
   val pp_info : info Fmt.t
+
+  val pp_info_with_argv : info Fmt.t
 
 end
 

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -434,5 +434,6 @@ let handle_command t (header, payload) =
     | `Command (`Unikernel_cmd vc) -> handle_unikernel_cmd t id vc
     | `Command (`Block_cmd bc) -> handle_block_cmd t id bc
     | _ ->
-      Logs.err (fun m -> m "ignoring %a" Vmm_commands.pp_wire (header, payload)) ;
+      Logs.err (fun m -> m "ignoring %a"
+                   (Vmm_commands.pp_wire ~verbose:false) (header, payload)) ;
       Error (`Msg "unknown command"))

--- a/stats/albatross_stats_pure.ml
+++ b/stats/albatross_stats_pure.ml
@@ -302,5 +302,6 @@ let handle t socket (hdr, wire) =
         Ok ({ t with name_sockets }, close, "subscribed")
     end
   | _ ->
-    Logs.err (fun m -> m "unexpected wire %a" Vmm_commands.pp_wire (hdr, wire)) ;
+    Logs.err (fun m -> m "unexpected wire %a"
+                 (Vmm_commands.pp_wire ~verbose:false) (hdr, wire)) ;
     Error (`Msg "unexpected command")

--- a/tls/albatross_tls_common.ml
+++ b/tls/albatross_tls_common.ml
@@ -21,7 +21,8 @@ let read version fd tls =
     Vmm_lwt.read_wire fd >>= function
     | Error _ -> Lwt.return (`Failure "exception while reading from fd")
     | Ok (hdr, pay) ->
-      Logs.debug (fun m -> m "read proxying %a" Vmm_commands.pp_wire (hdr, pay)) ;
+      Logs.debug (fun m -> m "read proxying %a"
+                     (Vmm_commands.pp_wire ~verbose:false) (hdr, pay)) ;
       let wire = { hdr with version }, pay in
       Vmm_tls_lwt.write_tls tls wire >>= function
       | Ok () -> loop ()
@@ -33,7 +34,8 @@ let process fd =
   Vmm_lwt.read_wire fd >|= function
   | Error _ -> `Failure "error reading from fd"
   | Ok (hdr, pay) ->
-    Logs.debug (fun m -> m "proxying %a" Vmm_commands.pp_wire (hdr, pay));
+    Logs.debug (fun m -> m "proxying %a"
+                   (Vmm_commands.pp_wire ~verbose:false) (hdr, pay));
     pay
 
 let handle tls =
@@ -70,7 +72,7 @@ let handle tls =
                      | Ok (_, `Success _) -> Ok ()
                      | Ok wire ->
                        Error (`Msg (Fmt.str "expected success when adding policy, got: %a"
-                                      Vmm_commands.pp_wire wire)))
+                                      (Vmm_commands.pp_wire ~verbose:false) wire)))
                (Ok ()) policies
            | _ -> Lwt.return (Ok ())) >>= function
           | Error (`Msg msg) ->

--- a/tls/vmm_tls.ml
+++ b/tls/vmm_tls.ml
@@ -72,7 +72,8 @@ let extract_policies chain =
         in
         Ok (name, (name, p) :: acc)
       | _, Ok wire ->
-        Error (`Msg (Fmt.str "unexpected wire %a" Vmm_commands.pp (snd wire))))
+        Error (`Msg (Fmt.str "unexpected wire %a"
+                       (Vmm_commands.pp ~verbose:false) (snd wire))))
     (Ok (Vmm_core.Name.root, [])) chain
 
 let handle chain =


### PR DESCRIPTION
avoid command line arguments being printed unless verbosity is debug.

fixes #92