### PR TITLE
Albatross_cli.create_vm: use uncompressed image for Vmm_unix.manifest_devices_match

### DIFF
--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -118,6 +118,7 @@ let create_vm force image cpuid memory argv block_devices bridges compression re
   let ( let* ) = Result.bind in
   let img_file = Fpath.v image in
   let* image = Bos.OS.File.read img_file in
+  let* () = Vmm_unix.manifest_devices_match ~bridges ~block_devices (Cstruct.of_string image) in
   let image, compressed = match compression with
     | 0 -> Cstruct.of_string image, false
     | level ->
@@ -128,7 +129,6 @@ let create_vm force image cpuid memory argv block_devices bridges compression re
     let exits = match exit_codes with [] -> None | xs -> Some (IS.of_list xs) in
     if restart_on_fail then `Restart exits else `Quit
   in
-  let* () = Vmm_unix.manifest_devices_match ~bridges ~block_devices image in
   let config = { Unikernel.typ = `Solo5 ; compressed ; image ; fail_behaviour ; cpuid ; memory ; block_devices ; bridges ; argv } in
   if force then Ok (`Unikernel_force_create config) else Ok (`Unikernel_create config)
 


### PR DESCRIPTION
Earlier, the compressed version was passed to manifest_devices_match, which
expects an ELF file (not a compressed one).

Spotted by @palainp in #101