### PR TITLE
Custom mac address

### DIFF
--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -320,7 +320,8 @@ let args =
   Arg.(value & opt_all string [] & info [ "arg" ] ~doc)
 
 let colon_separated_c =
-  let parse s = match String.split_on_char ':' s with
+  let parse s =
+    match String.split_on_char ':' s with
     | [ a ; b ] -> Ok (a, Some b)
     | [ _ ] -> Ok (s, None)
     | _ -> Error (`Msg "format is 'name' or 'name:device-name'")
@@ -333,9 +334,28 @@ let block =
   let doc = "Block device name (block or name:block-device-name)" in
   Arg.(value & opt_all colon_separated_c [] & info [ "block" ] ~doc)
 
+let net_with_mac =
+  let parse_net = Arg.conv_parser colon_separated_c in
+  let pp_net = Arg.conv_printer colon_separated_c in
+  let parse s =
+    let ( let* ) = Result.bind in
+    match String.split_on_char '@' s with
+    | [ net ] ->
+      let* (name, device_name) = parse_net net in
+      Ok (name, device_name, None)
+    | [ net; mac ] ->
+      let* mac = Macaddr.of_string mac in
+      let* (name, device_name) = parse_net net in
+      Ok (name, device_name, Some mac)
+    | _ -> Error (`Msg "format is FIXME") (* FIXME *)
+  and pp ppf (a, b, c) = (* FIXME *)
+    Fmt.pf ppf "%a%a" pp_net (a, b) Fmt.(option (append (any "@") Macaddr.pp)) c
+  in
+  Arg.conv (parse, pp)
+
 let net =
   let doc = "Network device names (bridge or name:bridge)" in
-  Arg.(value & opt_all colon_separated_c [] & info [ "net" ] ~doc)
+  Arg.(value & opt_all net_with_mac [] & info [ "net" ] ~doc)
 
 let restart_on_fail =
   let doc = "Restart on fail" in

--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -347,14 +347,14 @@ let net_with_mac =
       let* mac = Macaddr.of_string mac in
       let* (name, device_name) = parse_net net in
       Ok (name, device_name, Some mac)
-    | _ -> Error (`Msg "format is FIXME") (* FIXME *)
-  and pp ppf (a, b, c) = (* FIXME *)
-    Fmt.pf ppf "%a%a" pp_net (a, b) Fmt.(option (append (any "@") Macaddr.pp)) c
+    | _ -> Error (`Msg "format is [name:]bridge[@mac]")
+  and pp ppf (a, b, c) =
+    Fmt.pf ppf "%a%a" pp_net (a, b) Fmt.(option ((any "@") ++ Macaddr.pp)) c
   in
   Arg.conv (parse, pp)
 
 let net =
-  let doc = "Network device names (bridge or name:bridge)" in
+  let doc = "Network device names ([name:]bridge[@mac])" in
   Arg.(value & opt_all net_with_mac [] & info [ "net" ] ~doc)
 
 let restart_on_fail =

--- a/src/vmm_asn.ml
+++ b/src/vmm_asn.ml
@@ -164,6 +164,15 @@ let int64 =
   in
   Asn.S.map f g Asn.S.octet_string
 
+let mac_addr =
+  let f cs =
+    Result.fold (Macaddr.of_octets (Cstruct.to_string cs))
+      ~ok:Fun.id
+      ~error:(function `Msg e -> Asn.S.parse_error "bad mac address: %s" e)
+  and g mac = Cstruct.of_string (Macaddr.to_octets mac)
+  in
+  Asn.S.map f g Asn.S.octet_string
+
 let timeval =
   Asn.S.(sequence2
            (required ~label:"seconds" int64)
@@ -347,7 +356,7 @@ let v0_unikernel_config =
   in
   let open Unikernel in
   let f (cpuid, memory, block_device, network_interfaces, image, argv) =
-    let bridges = match network_interfaces with None -> [] | Some xs -> List.map (fun n -> n, None) xs
+    let bridges = match network_interfaces with None -> [] | Some xs -> List.map (fun n -> n, None, None) xs
     and block_devices = match block_device with None -> [] | Some b -> [ (b, None) ]
     in
     let typ = `Solo5
@@ -372,7 +381,7 @@ let v0_unikernel_config =
 let v1_unikernel_config =
   let open Unikernel in
   let f (typ, (compressed, (image, (fail_behaviour, (cpuid, (memory, (blocks, (bridges, argv)))))))) =
-    let bridges = match bridges with None -> [] | Some xs -> List.map (fun b -> b, None) xs
+    let bridges = match bridges with None -> [] | Some xs -> List.map (fun b -> b, None, None) xs
     and block_devices = match blocks with None -> [] | Some xs -> List.map (fun b -> b, None) xs
     in
     { typ ; compressed ; image ; fail_behaviour ; cpuid ; memory ; block_devices ; bridges ; argv }
@@ -392,12 +401,12 @@ let v1_unikernel_config =
 let v2_unikernel_config =
   let open Unikernel in
   let f (typ, (compressed, (image, (fail_behaviour, (cpuid, (memory, (blocks, (bridges, argv)))))))) =
-    let bridges = match bridges with None -> [] | Some xs -> xs
+    let bridges = match bridges with None -> [] | Some xs -> List.map (fun (a, b) -> (a, b, None)) xs
     and block_devices = match blocks with None -> [] | Some xs -> List.map (fun b -> b, None) xs
     in
     { typ ; compressed ; image ; fail_behaviour ; cpuid ; memory ; block_devices ; bridges ; argv }
   and g (vm : config) =
-    let bridges = match vm.bridges with [] -> None | xs -> Some xs
+    let bridges = match vm.bridges with [] -> None | xs -> Some (List.map (fun (a,b,_) -> a, b) xs) (* FIXME *)
     and blocks = match vm.block_devices with
       | [] -> None
       | xs -> Some (List.map fst xs)
@@ -414,6 +423,38 @@ let v2_unikernel_config =
          @ (optional ~label:"blocks" (my_explicit 0 (set_of utf8_string)))
          @ (optional ~label:"bridges"
               (my_explicit 1 (sequence_of
+                             (sequence2
+                                (required ~label:"netif" utf8_string)
+                                (optional ~label:"bridge" utf8_string)))))
+        -@ (optional ~label:"arguments"(my_explicit 2 (sequence_of utf8_string))))
+
+let v3_unikernel_config =
+  let open Unikernel in
+  let f (typ, (compressed, (image, (fail_behaviour, (cpuid, (memory, (blocks, (bridges, argv)))))))) =
+    let bridges = match bridges with None -> [] | Some xs -> List.map (fun (a,b) -> a,b,None) xs
+    and block_devices = match blocks with None -> [] | Some xs -> xs
+    in
+    { typ ; compressed ; image ; fail_behaviour ; cpuid ; memory ; block_devices ; bridges ; argv }
+  and g (vm : config) =
+    let bridges = match vm.bridges with [] -> None | xs -> Some (List.map (fun (a,b,_) -> a,b) xs) (* FIXME *)
+    and blocks = match vm.block_devices with [] -> None | xs -> Some xs
+    in
+    (vm.typ, (vm.compressed, (vm.image, (vm.fail_behaviour, (vm.cpuid, (vm.memory, (blocks, (bridges, vm.argv))))))))
+  in
+  Asn.S.(map f g @@ sequence @@
+           (required ~label:"typ" typ)
+         @ (required ~label:"compressed" bool)
+         @ (required ~label:"image" octet_string)
+         @ (required ~label:"fail-behaviour" fail_behaviour)
+         @ (required ~label:"cpuid" int)
+         @ (required ~label:"memory" int)
+         @ (optional ~label:"blocks"
+              (my_explicit 0 (set_of
+                                (sequence2
+                                   (required ~label:"block-name" utf8_string)
+                                   (optional ~label:"block-device-name" utf8_string)))))
+         @ (optional ~label:"bridges"
+              (my_explicit 1 (set_of
                              (sequence2
                                 (required ~label:"netif" utf8_string)
                                 (optional ~label:"bridge" utf8_string)))))
@@ -446,9 +487,10 @@ let unikernel_config =
                                    (optional ~label:"block-device-name" utf8_string)))))
          @ (optional ~label:"bridges"
               (my_explicit 1 (set_of
-                             (sequence2
+                             (sequence3
                                 (required ~label:"netif" utf8_string)
-                                (optional ~label:"bridge" utf8_string)))))
+                                (optional ~label:"bridge" utf8_string)
+                                (optional ~label:"mac" mac_addr)))))
         -@ (optional ~label:"arguments"(my_explicit 2 (sequence_of utf8_string))))
 
 let unikernel_cmd =
@@ -465,17 +507,19 @@ let unikernel_cmd =
     | `C2 `C4 vm -> `Unikernel_create vm
     | `C2 `C5 vm -> `Unikernel_force_create vm
     | `C2 `C6 level -> `Unikernel_get level
+    | `C3 `C1 vm -> `Unikernel_create vm
+    | `C3 `C2 vm -> `Unikernel_force_create vm
   and g = function
     | `Old_unikernel_info -> `C1 (`C1 ())
-    | `Unikernel_create vm -> `C2 (`C4 vm)
-    | `Unikernel_force_create vm -> `C2 (`C5 vm)
+    | `Unikernel_create vm -> `C3 (`C1 vm)
+    | `Unikernel_force_create vm -> `C3 (`C2 vm)
     | `Unikernel_destroy -> `C1 (`C4 ())
     | `Old_unikernel_get -> `C2 (`C1 ())
     | `Unikernel_info -> `C2 (`C2 ())
     | `Unikernel_get level -> `C2 (`C6 level)
   in
   Asn.S.map f g @@
-  Asn.S.(choice2
+  Asn.S.(choice3
           (choice6
              (my_explicit 0 ~label:"info-OLD" null)
              (my_explicit 1 ~label:"create-OLD1" v1_unikernel_config)
@@ -487,9 +531,12 @@ let unikernel_cmd =
              (my_explicit 6 ~label:"get-OLD" null)
              (my_explicit 7 ~label:"info" null)
              (my_explicit 8 ~label:"get-OLD2" null)
-             (my_explicit 9 ~label:"create" unikernel_config)
-             (my_explicit 10 ~label:"force-create" unikernel_config)
-             (my_explicit 11 ~label:"get" int)))
+             (my_explicit 9 ~label:"create-OLD3" v3_unikernel_config)
+             (my_explicit 10 ~label:"force-create-OLD3" v3_unikernel_config)
+             (my_explicit 11 ~label:"get" int))
+          (choice2
+            (my_explicit 12 ~label:"create" unikernel_config)
+            (my_explicit 13 ~label:"force-create" unikernel_config)))
 
 let policy_cmd =
   let f = function
@@ -614,9 +661,10 @@ let unikernel_info =
                                    (optional ~label:"block-device-name" utf8_string)))))
          @ (optional ~label:"bridges"
               (my_explicit 1 (set_of
-                                (sequence2
+                                (sequence3
                                    (required ~label:"net-name" utf8_string)
-                                   (optional ~label:"bridge-name" utf8_string)))))
+                                   (optional ~label:"bridge-name" utf8_string)
+                                   (optional ~label:"mac" mac_addr)))))
         -@ (optional ~label:"arguments"(my_explicit 2 (sequence_of utf8_string))))
 
 let header name =

--- a/src/vmm_asn.ml
+++ b/src/vmm_asn.ml
@@ -406,7 +406,10 @@ let v2_unikernel_config =
     in
     { typ ; compressed ; image ; fail_behaviour ; cpuid ; memory ; block_devices ; bridges ; argv }
   and g (vm : config) =
-    let bridges = match vm.bridges with [] -> None | xs -> Some (List.map (fun (a,b,_) -> a, b) xs) (* FIXME *)
+    let bridges =
+      match vm.bridges with
+      | [] -> None
+      | xs -> Some (List.map (fun (a, b, _) -> a, b) xs)
     and blocks = match vm.block_devices with
       | [] -> None
       | xs -> Some (List.map fst xs)
@@ -436,7 +439,10 @@ let v3_unikernel_config =
     in
     { typ ; compressed ; image ; fail_behaviour ; cpuid ; memory ; block_devices ; bridges ; argv }
   and g (vm : config) =
-    let bridges = match vm.bridges with [] -> None | xs -> Some (List.map (fun (a,b,_) -> a,b) xs) (* FIXME *)
+    let bridges =
+      match vm.bridges with
+      | [] -> None
+      | xs -> Some (List.map (fun (a, b, _) -> a, b) xs)
     and blocks = match vm.block_devices with [] -> None | xs -> Some xs
     in
     (vm.typ, (vm.compressed, (vm.image, (vm.fail_behaviour, (vm.cpuid, (vm.memory, (blocks, (bridges, vm.argv))))))))

--- a/src/vmm_core.ml
+++ b/src/vmm_core.ml
@@ -267,13 +267,13 @@ module Unikernel = struct
     cpuid : int ;
     memory : int ;
     block_devices : (string * string option) list ;
-    bridges : (string * string option) list ;
+    bridges : (string * string option * Macaddr.t option) list ;
     argv : string list option ;
   }
 
   let bridges (vm : config) =
     List.map
-      (fun (net, bri) -> match bri with None -> net | Some s -> s)
+      (fun (net, bri, _mac) -> match bri with None -> net | Some s -> s)
       vm.bridges
 
   let pp_opt_list ppf xs =
@@ -290,7 +290,7 @@ module Unikernel = struct
       pp_fail_behaviour vm.fail_behaviour
       vm.cpuid vm.memory
       pp_opt_list vm.block_devices
-      pp_opt_list vm.bridges
+      pp_opt_list (List.map (fun (x,y,_z) -> (x, y)) vm.bridges) (* FIXME *)
 
   let pp_config_with_argv ppf (vm : config) =
     Fmt.pf ppf "%a@ argv %a" pp_config vm
@@ -322,7 +322,7 @@ module Unikernel = struct
     cpuid : int ;
     memory : int ;
     block_devices : (string * string option) list ;
-    bridges : (string * string option) list ;
+    bridges : (string * string option * Macaddr.t option) list ;
     argv : string list option ;
     digest : Cstruct.t ;
   }
@@ -340,7 +340,7 @@ module Unikernel = struct
       pp_fail_behaviour info.fail_behaviour
       info.cpuid info.memory
       pp_opt_list info.block_devices
-      pp_opt_list info.bridges
+      pp_opt_list (List.map (fun (x,y,_z) -> (x,y)) info.bridges) (* FIXME *)
       hex_digest
 
   let pp_info_with_argv ppf (info : info) =

--- a/src/vmm_core.ml
+++ b/src/vmm_core.ml
@@ -280,7 +280,11 @@ module Unikernel = struct
     Fmt.(list ~sep:(any ", ")
            (pair ~sep:(any " -> ") string string))
       ppf
-      (List.map (fun (a, b) -> a, (match b with None -> a | Some b -> b)) xs)
+      (List.map (fun (a, b) -> a, Option.value ~default:a b) xs)
+
+  let pp_bridge ppf (name, bridge, mac) =
+    Fmt.pf ppf "%s -> %s%a" name (Option.value ~default:name bridge)
+      Fmt.(option ((any "@") ++ Macaddr.pp)) mac
 
   let pp_config ppf (vm : config) =
     Fmt.pf ppf "typ %a@ compression %B image %d bytes@ fail behaviour %a@ cpu %d@ %d MB memory@ block devices %a@ bridge %a"
@@ -290,7 +294,7 @@ module Unikernel = struct
       pp_fail_behaviour vm.fail_behaviour
       vm.cpuid vm.memory
       pp_opt_list vm.block_devices
-      pp_opt_list (List.map (fun (x,y,_z) -> (x, y)) vm.bridges) (* FIXME *)
+      Fmt.(list ~sep:(any ", ") pp_bridge) vm.bridges
 
   let pp_config_with_argv ppf (vm : config) =
     Fmt.pf ppf "%a@ argv %a" pp_config vm
@@ -340,7 +344,7 @@ module Unikernel = struct
       pp_fail_behaviour info.fail_behaviour
       info.cpuid info.memory
       pp_opt_list info.block_devices
-      pp_opt_list (List.map (fun (x,y,_z) -> (x,y)) info.bridges) (* FIXME *)
+      Fmt.(list ~sep:(any ", ") pp_bridge) info.bridges
       hex_digest
 
   let pp_info_with_argv ppf (info : info) =

--- a/src/vmm_core.mli
+++ b/src/vmm_core.mli
@@ -105,7 +105,7 @@ module Unikernel : sig
     cpuid : int ;
     memory : int ;
     block_devices : (string * string option) list ;
-    bridges : (string * string option) list ;
+    bridges : (string * string option * Macaddr.t option) list ;
     argv : string list option ;
   }
 
@@ -133,7 +133,7 @@ module Unikernel : sig
     cpuid : int ;
     memory : int ;
     block_devices : (string * string option) list ;
-    bridges : (string * string option) list ;
+    bridges : (string * string option * Macaddr.t option) list ;
     argv : string list option ;
     digest : Cstruct.t ;
   }

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -238,12 +238,12 @@ let devices_match ~bridges ~block_devices (manifest_block, manifest_net) =
 
 let manifest_devices_match ~bridges ~block_devices image =
   let* things = solo5_image_devices image in
-  let bridges = List.map fst bridges
+  let bridges = List.map (fun (b,_,_) -> b) bridges
   and block_devices = List.map fst block_devices
   in
   devices_match ~bridges ~block_devices things
 
-let bridge_name (service, b) = match b with None -> service | Some b -> b
+let bridge_name (service, b, _mac) = match b with None -> service | Some b -> b
 
 let bridge_exists bridge_name =
   let cmd =
@@ -302,7 +302,8 @@ let prepare name (vm : Unikernel.config) =
         let* acc = acc in
         let bridge = bridge_name arg in
         let* tap = create_tap bridge in
-        Ok ((fst arg, tap) :: acc))
+        let (service, _, _) = arg in
+        Ok ((service, tap) :: acc))
       (Ok []) vm.Unikernel.bridges
   in
   Ok (List.rev taps, digest)

--- a/src/vmm_unix.mli
+++ b/src/vmm_unix.mli
@@ -13,9 +13,9 @@ val set_dbdir : Fpath.t -> unit
 val check_commands : unit -> (unit, [> `Msg of string ]) result
 
 val prepare : Name.t -> Unikernel.config ->
-  ((string * string) list * Cstruct.t, [> `Msg of string ]) result
+  ((string * string * Macaddr.t option) list * Cstruct.t, [> `Msg of string ]) result
 
-val exec : Name.t -> Unikernel.config -> (string * string) list ->
+val exec : Name.t -> Unikernel.config -> (string * string * Macaddr.t option) list ->
   (string * Name.t) list -> Cstruct.t -> (Unikernel.t, [> `Msg of string ]) result
 
 val free_system_resources : Name.t -> string list -> (unit, [> `Msg of string ]) result

--- a/src/vmm_unix.mli
+++ b/src/vmm_unix.mli
@@ -40,6 +40,6 @@ val restore : ?name:string -> unit -> (Cstruct.t, [> `Msg of string | `NoFile ])
 
 val vm_device : Unikernel.t -> (string, [> `Msg of string ]) result
 
-val manifest_devices_match : bridges:(string * string option) list ->
+val manifest_devices_match : bridges:(string * string option * Macaddr.t option) list ->
   block_devices:(string * string option) list -> Cstruct.t ->
   (unit, [> `Msg of string]) result

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -175,9 +175,11 @@ let handle_create t name vm_config =
   let* () = Vmm_resources.check_vm t.resources name vm_config in
   (* prepare VM: save VM image to disk, create fifo, ... *)
   let* taps, digest = Vmm_unix.prepare name vm_config in
+  let pp_tap ppf (a, b, mac) =
+    Fmt.pf ppf "%s -> %s%a" a b Fmt.(option ((any "@") ++ Macaddr.pp)) mac
+  in
   Logs.debug (fun m -> m "prepared vm with taps %a"
-                 Fmt.(list ~sep:(any ",@ ") (pair ~sep:(any " -> ") string string))
-                 (List.map (fun (a,b,_) -> a,b) taps (* FIXME *))) ;
+                 Fmt.(list ~sep:(any ",@ ") pp_tap) taps) ;
   let cons_out =
     let header = Vmm_commands.header ~sequence:t.console_counter name in
     (header, `Command (`Console_cmd `Console_add))

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -177,7 +177,7 @@ let handle_create t name vm_config =
   let* taps, digest = Vmm_unix.prepare name vm_config in
   Logs.debug (fun m -> m "prepared vm with taps %a"
                  Fmt.(list ~sep:(any ",@ ") (pair ~sep:(any " -> ") string string))
-                 taps) ;
+                 (List.map (fun (a,b,_) -> a,b) taps (* FIXME *))) ;
   let cons_out =
     let header = Vmm_commands.header ~sequence:t.console_counter name in
     (header, `Command (`Console_cmd `Console_add))
@@ -204,7 +204,7 @@ let handle_create t name vm_config =
     let t, stat_out = setup_stats t name vm in
     Ok (t, stat_out, `Success (`String "created VM"), name, vm)
   and fail () =
-    match Vmm_unix.free_system_resources name (List.map snd taps) with
+    match Vmm_unix.free_system_resources name (List.map (fun (_,tap,_) -> tap) taps) with
     | Ok () -> `Failure "could not create VM: console failed"
     | Error (`Msg msg) ->
       let m = "could not create VM: console failed, and also " ^ msg ^ " while cleaning resources" in

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -152,7 +152,7 @@ let setup_stats t name vm =
     let name = match Vmm_unix.vm_device vm with
       | Error _ -> ""
       | Ok name -> name
-    and ifs = Unikernel.(List.combine (List.map fst vm.config.bridges) vm.taps)
+    and ifs = Unikernel.(List.combine (List.map (fun (x,_,_) -> x) vm.config.bridges) vm.taps)
     in
     `Stats_add (name, vm.Unikernel.pid, ifs)
   in

--- a/test/albatross_client_gen.ml
+++ b/test/albatross_client_gen.ml
@@ -5,7 +5,7 @@ let u1 =
     typ = `Solo5 ; compressed = false ; image = Cstruct.empty ;
     fail_behaviour = `Quit ; cpuid = 0 ; memory = 1 ;
     block_devices = [ "block", None ; "secondblock", Some "second-data" ] ;
-    bridges = [ "service", None ; "other-net", Some "second-bridge" ] ;
+    bridges = [ "service", None, None ; "other-net", Some "second-bridge", None ] ;
     argv = Some [ "-l *:debug" ] ;
   }
 
@@ -14,7 +14,7 @@ let u2 =
     typ = `Solo5 ; compressed = false ; image = Cstruct.empty ;
     fail_behaviour = `Quit ; cpuid = 2 ; memory = 10 ;
     block_devices = [] ;
-    bridges = [ "service", Some "bridge-interface" ] ;
+    bridges = [ "service", Some "bridge-interface", None ] ;
     argv = None ;
   }
 

--- a/test/albatross_client_gen.ml
+++ b/test/albatross_client_gen.ml
@@ -14,7 +14,7 @@ let u2 =
     typ = `Solo5 ; compressed = false ; image = Cstruct.empty ;
     fail_behaviour = `Quit ; cpuid = 2 ; memory = 10 ;
     block_devices = [] ;
-    bridges = [ "service", Some "bridge-interface", None ] ;
+    bridges = [ "service", Some "bridge-interface", Some (Macaddr.of_string_exn "00:de:ad:be:ef:00") ] ;
     argv = None ;
   }
 

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -955,6 +955,16 @@ let unikernels1_path =
   let t = ins "foo:my.nice.unikernel" u1_1 t in
   ins "bar:my.nice.unikernel" u2_1 t
 
+let unikernels_with_mac =
+  let u2 =
+    let bridges = [ "service", Some "bridge-interface", Some (Macaddr.of_string_exn "00:de:ad:be:ef:00") ] in
+    { u2_3 with bridges }
+  in
+  let t = ins "foo:hello" u1_3 Vmm_trie.empty in
+  let t = ins "bar:hello" u2 t in
+  let t = ins "foo:my.nice.unikernel" u1_3 t in
+  ins "bar:my.nice.unikernel" u2 t
+
 let wire4_unikernel3_path () =
   let trie = dec_b64_unik ~migrate_name:true wire4_unikernel3_data in
   Alcotest.check test_unikernels __LOC__ unikernels3_path trie
@@ -1015,6 +1025,13 @@ let wire5_unikernel1_path_migrate () =
   let trie = dec_b64_unik ~migrate_name:true wire5_unikernel1_path_data in
   Alcotest.check test_unikernels __LOC__ unikernels1_path trie
 
+let wire5_unikernel3_with_mac () =
+  let data =
+    {|o4IBwDCCAbwwSQwJYmFyOmhlbGxvMDygAgUAAQEABACgAgUAAgECAgEKoScxJTAjDAdzZXJ2aWNlDBBicmlkZ2UtaW50ZXJmYWNlBAYA3q2+7wAwVQwVYmFyOm15Lm5pY2UudW5pa2VybmVsMDygAgUAAQEABACgAgUAAgECAgEKoScxJTAjDAdzZXJ2aWNlDBBicmlkZ2UtaW50ZXJmYWNlBAYA3q2+7wAwgYQMCWZvbzpoZWxsbzB3oAIFAAEBAAQAoAIFAAIBAAIBAaAnMSUwBwwFYmxvY2swGgwLc2Vjb25kYmxvY2sMC3NlY29uZC1kYXRhoSkxJzAJDAdzZXJ2aWNlMBoMCW90aGVyLW5ldAwNc2Vjb25kLWJyaWRnZaIOMAwMCi1sICo6ZGVidWcwgZAMFWZvbzpteS5uaWNlLnVuaWtlcm5lbDB3oAIFAAEBAAQAoAIFAAIBAAIBAaAnMSUwBwwFYmxvY2swGgwLc2Vjb25kYmxvY2sMC3NlY29uZC1kYXRhoSkxJzAJDAdzZXJ2aWNlMBoMCW90aGVyLW5ldAwNc2Vjb25kLWJyaWRnZaIOMAwMCi1sICo6ZGVidWc=|}
+  in
+  let trie = dec_b64_unik ~migrate_name:false data in
+  Alcotest.check test_unikernels __LOC__ unikernels_with_mac trie
+
 let wire_tests = [
   "Wire version 4, unikernel version 3", `Quick, wire4_unikernel3 ;
   "Wire version 4, unikernel version 2", `Quick, wire4_unikernel2 ;
@@ -1034,6 +1051,7 @@ let wire_tests = [
   "Wire version 5, unikernel version 3, path, migrate", `Quick, wire5_unikernel3_path_migrate ;
   "Wire version 5, unikernel version 2, path, migrate", `Quick, wire5_unikernel2_path_migrate ;
   "Wire version 5, unikernel version 1, path, migrate", `Quick, wire5_unikernel1_path_migrate ;
+  "Wire version 5, unikernel version 3, with mac", `Quick, wire5_unikernel3_with_mac ;
 ]
 
 let tests = [


### PR DESCRIPTION
This PR extends the `--net` command line argument to take an optional mac address separated by an ampersand. The format is `--net=service:bridge@00:11:22:33:44:55`.

Things to do:
- [x] Fix pretty printing of optional mac address.
- [x] Fix the ASN.1. I'm confused how much backwards compatibility we need.
- [x] Actually pass `--net-mac` to solo5.
- [ ] ~~Consider how it fits in with the resource policies. Likely, we want to be able to put restrictions on the use of custom mac addresses.~~