### PR TITLE
Fix 105

### DIFF
--- a/packaging/Linux/albatross_console.service
+++ b/packaging/Linux/albatross_console.service
@@ -9,6 +9,7 @@ After=syslog.target
 [Service]
 Type=simple
 User=albatross
+Group=albatross
 ExecStart=/usr/libexec/albatross/albatross-console --systemd-socket-activation --tmpdir="%t/albatross/" -vv
 PIDFile=%t/albatross/console.pid
 RestrictAddressFamilies=AF_UNIX

--- a/packaging/Linux/albatross_daemon.service
+++ b/packaging/Linux/albatross_daemon.service
@@ -8,9 +8,8 @@ Type=simple
 # TODO not necessarily needs to be run as root, anything that can solo5-spt/hvt,
 #  create tap interfaces should be fine!
 User=root
+Group=albatross
 ExecStart=/usr/libexec/albatross/albatrossd --systemd-socket-activation --tmpdir="%t/albatross/" -vv
-#RuntimeDirectoryPreserve=yes
-#RuntimeDirectory=albatross
 PIDFile=%t/albatross/daemon.pid
 RuntimeDirectoryPreserve=yes
 RuntimeDirectory=albatross

--- a/packaging/Linux/albatross_influx.service
+++ b/packaging/Linux/albatross_influx.service
@@ -9,6 +9,7 @@ After=syslog.target
 [Service]
 Type=simple
 User=albatross
+Group=albatross
 ExecStart=/usr/libexec/albatross/albatross-influx --influx=127.0.0.1 --tmpdir="%t/albatross/" -vv
 
 [Install]

--- a/packaging/Linux/albatross_stats.service
+++ b/packaging/Linux/albatross_stats.service
@@ -9,6 +9,7 @@ After=syslog.target
 [Service]
 Type=simple
 User=albatross
+Group=albatross
 ExecStart=/usr/libexec/albatross/albatross-stats --systemd-socket-activation --tmpdir="%t/albatross/" -vv
 RuntimeDirectoryPreserve=yes
 RuntimeDirectory=albatross albatross/util


### PR DESCRIPTION
I found that systemd would create `/run/albatross/fifo/` with permissions `drwxrws---  root root`. A new commit is added where Group is set to albatross in all systemd service files. The group albatross should be implied by `User=albatross` so it should only be strictly necessary to put it in albatross_daemon.service.