### PR TITLE
Refactor albatross stats stubs

### DIFF
--- a/stats/albatross_stat_client.ml
+++ b/stats/albatross_stat_client.ml
@@ -26,8 +26,7 @@ let timer pid vmmapi interval =
   | None -> ()
   | Some vmctx -> match wrap vmmapi_stats vmctx with
     | None -> Logs.app (fun m -> m "no vmctx stats")
-    | Some st ->
-      let all = List.combine !descr st in
+    | Some all ->
       Logs.app (fun m -> m "bhyve stats %a" Stats.pp_vmm_mem all)
 
 let jump _ pid name interval tmpdir =
@@ -45,7 +44,6 @@ let jump _ pid name interval tmpdir =
           None
         | Some vmctx ->
           Logs.info (fun m -> m "vmmapi_open succeeded for %s" name) ;
-          fill_descr vmctx ;
           Some vmctx
     in
     let _ev = Lwt_engine.on_timer interval true (fun _e -> timer pid vmmapi interval) in

--- a/stats/albatross_stats_pure.ml
+++ b/stats/albatross_stats_pure.ml
@@ -15,10 +15,7 @@ type vmctx
 
 external vmmapi_open : string -> vmctx = "vmmanage_vmmapi_open"
 external vmmapi_close : vmctx -> unit = "vmmanage_vmmapi_close"
-external vmmapi_statnames : vmctx -> string list = "vmmanage_vmmapi_statnames"
-external vmmapi_stats : vmctx -> int64 list = "vmmanage_vmmapi_stats"
-
-let descr = ref []
+external vmmapi_stats : vmctx -> (string * int64) list = "vmmanage_vmmapi_stats"
 
 type 'a t = {
   pid_nic : ((vmctx, int) result * string * (string * int * string) list) IM.t ;
@@ -61,19 +58,6 @@ let remove_vmid t vmid =
     in
     { t with pid_nic ; vmid_pid }
 
-let fill_descr ctx =
-  match !descr with
-  | [] ->
-    begin match wrap vmmapi_statnames ctx with
-      | None ->
-        Logs.err (fun m -> m "vmmapi_statnames failed, shouldn't happen") ;
-        ()
-      | Some d ->
-        Logs.debug (fun m -> m "descr are %a" pp_strings d) ;
-        descr := d
-    end
-  | ds -> Logs.debug (fun m -> m "%d descr are already present" (List.length ds))
-
 let open_vmmapi ~retries name =
   if retries = 0 then begin
     Logs.debug (fun m -> m "(ignored 0) vmmapi_open failed for %s" name) ;
@@ -87,7 +71,6 @@ let open_vmmapi ~retries name =
     | Some vmctx ->
       vmmapi `Open;
       Logs.info (fun m -> m "vmmapi_open succeeded for %s" name) ;
-      fill_descr vmctx ;
       Ok vmctx
 
 let try_open_vmmapi pid_nic =
@@ -250,8 +233,7 @@ let tick t =
               out, vmid :: to_remove
             | Some ru' ->
               let stats =
-                let vmm' = match vmm with None -> None | Some xs -> Some (List.combine !descr xs) in
-                ru', mem, vmm', ifd
+                ru', mem, vmm, ifd
               in
               let outs =
                 List.fold_left (fun out (id, (version, socket)) ->

--- a/stats/albatross_stats_pure.ml
+++ b/stats/albatross_stats_pure.ml
@@ -213,8 +213,8 @@ let gather pid vmctx nics =
       | Some data -> { data with Stats.bridge }::ifd)
     [] nics
 
-let tick t =
-  let pid_nic = try_open_vmmapi t.pid_nic in
+let tick gather_bhyve t =
+  let pid_nic = if gather_bhyve then try_open_vmmapi t.pid_nic else t.pid_nic in
   let t' = { t with pid_nic } in
   let outs, to_remove =
     List.fold_left (fun (out, to_remove) (vmid, pid) ->

--- a/stats/albatross_stats_stubs.c
+++ b/stats/albatross_stats_stubs.c
@@ -126,39 +126,23 @@ CAMLprim value vmmanage_vmmapi_close (value octx) {
   return Val_unit;
 }
 
-CAMLprim value vmmanage_vmmapi_statnames (value octx) {
-  CAMLparam0();
-  CAMLlocal2(res, tmp);
-  struct vmctx *ctx = (struct vmctx*)octx;
-  int i, num_stats;
-  uint64_t *s;
-  const char *desc;
-
-  s = vm_get_stats(ctx, 0, NULL, &num_stats);
-  if (s != NULL) {
-    for (i = 0; i < num_stats; i++) {
-      desc = vm_get_stat_desc(ctx, i);
-      tmp = caml_alloc(2, 0);
-      Store_field (tmp, 0, caml_copy_string(desc));
-      Store_field (tmp, 1, res);
-      res = tmp;
-    }
-  }
-  CAMLreturn(res);
-}
-
 CAMLprim value vmmanage_vmmapi_stats (value octx) {
   CAMLparam0();
-  CAMLlocal2(res, tmp);
+  CAMLlocal3(res, tmp, pair);
   int i, num_stats;
   uint64_t *stats;
+  const char *desc;
   struct vmctx *ctx = (struct vmctx*)octx;
 
   stats = vm_get_stats(ctx, 0, NULL, &num_stats);
   if (stats != NULL) {
     for (i = 0; i < num_stats; i++) {
       tmp = caml_alloc(2, 0);
-      Store_field (tmp, 0, Val64(stats[i]));
+      pair = caml_alloc_tuple(2);
+      desc = vm_get_stat_desc(ctx, i);
+      Store_field (pair, 0, caml_copy_string(desc));
+      Store_field (pair, 1, Val64(stats[i]));
+      Store_field (tmp, 0, pair);
       Store_field (tmp, 1, res);
       res = tmp;
     }
@@ -350,11 +334,6 @@ CAMLprim value vmmanage_vmmapi_close (value name) {
 CAMLprim value vmmanage_vmmapi_stats (value name) {
   CAMLparam1(name);
   uerror("vmmapi_stats", Nothing);
-}
-
-CAMLprim value vmmanage_vmmapi_statnames (value name) {
-  CAMLparam1(name);
-  uerror("vmmapi_statnames", Nothing);
 }
 
 #endif


### PR DESCRIPTION
In #115 an exception from `List.combine` is raised. With `git grep` I found two sites that call `List.combine`. One place it's called with `taps` and `vm.config.bridges`. This should be fine since the former is constructed from the latter.
The other place is in `albatross_stats_pure.ml` in order to associate a statistic / counter value with a string description. Previously, the statistics description strings was fetched once when opening the first VM. From what I could gather the number of VM statistic counters depends on the number of CPUs assigned, so my hypothesis is the number of counters for the first VM may have differed from a later VM.

This patch makes `vmmanage_vmmapi_stats` return `(string * int64) list`  instead of a `int64 list` where the string is the description fetched with `vm_get_stat_desc` at each `vmmanage_vmmapi_stats` call. This may be less efficient.

Ideally, we would somehow verify my hypothesis, and maybe benchmark the performance impact of this patch.