### PR TITLE
tls-endpoint: Listen on systemd socket

### DIFF
--- a/daemon/albatross_console.ml
+++ b/daemon/albatross_console.ml
@@ -160,9 +160,13 @@ let m = Vmm_core.conn_metrics "unix"
 let jump _ systemd influx tmpdir =
   Sys.(set_signal sigpipe Signal_ignore) ;
   Albatross_cli.set_tmpdir tmpdir;
+  let socket () =
+    if systemd then Vmm_lwt.systemd_socket ()
+    else Vmm_lwt.service_socket `Console
+  in
   Lwt_main.run
     (Albatross_cli.init_influx "albatross_console" influx;
-     Vmm_lwt.server_socket ~systemd `Console >>= fun s ->
+     socket () >>= fun s ->
      let rec loop () =
        Lwt_unix.accept s >>= fun (cs, addr) ->
        m `Open;

--- a/daemon/albatrossd.ml
+++ b/daemon/albatrossd.ml
@@ -168,8 +168,11 @@ let jump _ systemd influx tmpdir dbdir retries enable_stats migrate_name =
           Some s
         else
           Lwt.return_none) >>= fun s ->
-       Lwt.catch
-         (fun () -> Vmm_lwt.server_socket ~systemd `Vmmd)
+       let listen_socket () =
+         if systemd then Vmm_lwt.systemd_socket ()
+         else Vmm_lwt.service_socket `Vmmd
+       in
+       Lwt.catch listen_socket
          (fun e ->
             let str =
               Fmt.str "unable to create server socket %a: %s"

--- a/packaging/Linux/albatross_tls_endpoint.service
+++ b/packaging/Linux/albatross_tls_endpoint.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Albatross tls endpoint
+requires=albatross_daemon.socket albatross_tls_endpoint.socket
+After=syslog.target network.target
+
+[Service]
+Type=simple
+User=albatross
+Group=albatross
+# Either replace ${CA}, ${CERT} and ${KEY} with paths, or
+# add Environment=CA=/path/to/ca.pem directives.
+ExecStart=/usr/libexec/albatross/albatross-tls-endpoint --systemd-socket-activation --tmpdir="%t/albatross/" "${CA}" "${CERT}" "${KEY}"
+
+[Install]
+Also=albatross_tls_endpoint.socket
+WantedBy=multi-user.target

--- a/packaging/Linux/albatross_tls_endpoint.socket
+++ b/packaging/Linux/albatross_tls_endpoint.socket
@@ -1,0 +1,11 @@
+[Unit]
+Description=Albatross tls endpoint listening for requests
+PartOf=albatross_tls_endpoint.service
+
+[Socket]
+# Modify address as needed. Default is to listen on port 1025 on all interfaces.
+ListenStream=1025
+SocketUser=albatross
+
+[Install]
+WantedBy=sockets.target

--- a/packaging/debian/create_package.sh
+++ b/packaging/debian/create_package.sh
@@ -14,11 +14,12 @@ rootdir=$tmpd/rootdir
 libexecdir=$rootdir/usr/libexec/albatross
 bindir=$rootdir/usr/bin
 systemddir=$rootdir/usr/lib/systemd/system
+examplesdir=$rootdir/usr/share/doc/albatross/examples
 debiandir=$rootdir/DEBIAN
 
 trap 'rm -rf $tmpd' 0 INT EXIT
 
-mkdir -p "$libexecdir" "$bindir" "$debiandir" "$systemddir"
+mkdir -p "$libexecdir" "$bindir" "$debiandir" "$systemddir" "$examplesdir"
 
 # stage daemon binaries
 for f in albatrossd \
@@ -49,6 +50,10 @@ do
 done
 install -m 0644 $basedir/packaging/Linux/albatross_influx.service \
         $systemddir/albatross_influx.service
+install -m 0644 $basedir/packaging/Linux/albatross_tls_endpoint.service \
+	$examplesdir/albatross_tls_endpoint.service
+install -m 0644 $basedir/packaging/Linux/albatross_tls_endpoint.socket \
+	$examplesdir/albatross_tls_endpoint.socket
 
 # install debian metadata
 install -m 0644 $basedir/packaging/debian/control $debiandir/control

--- a/src/vmm_lwt.mli
+++ b/src/vmm_lwt.mli
@@ -2,7 +2,14 @@
 
 val pp_sockaddr : Format.formatter -> Lwt_unix.sockaddr -> unit
 
-val server_socket : systemd:bool -> Vmm_core.service -> Lwt_unix.file_descr Lwt.t
+(** Listen on a port. *)
+val port_socket : int -> Lwt_unix.file_descr Lwt.t
+
+(** Listen on a socket passed by systemd through a variable. *)
+val systemd_socket : unit -> Lwt_unix.file_descr Lwt.t
+
+(** Listen on a socket bound to a service. *)
+val service_socket : Vmm_core.service -> Lwt_unix.file_descr Lwt.t
 
 val connect : Lwt_unix.socket_domain -> Lwt_unix.sockaddr -> Lwt_unix.file_descr option Lwt.t
 


### PR DESCRIPTION
Add support to `albatross-tls-endpoint` for listening on a systemd socket. This is useful to let systemd open priviledge ports safely.

The '--port' option is kept for compatibility and could also be added to the other commands thanks to a reusable cmdliner term.