### PR TITLE
Deploy albatross using NixOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,49 @@ jobs:
 
       - name: Test
         run: opam exec -- dune runtest
+
+  nix:
+    name: Test the Nix package
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Cache the Nix store
+        uses: actions/cache@v3
+        with:
+          key: nix-store-${{runner.arch}}-${{runner.os}}
+          path: |
+            /tmp/nix_store
+            /tmp/nix_store_db
+
+      # Inspired from https://github.com/tpwrules/nixos-m1/blob/22f39d12f022deddf0a4f8e5139b8b88f12e95ed/.github/workflows/installer.yml
+      - name: Restore the Nix store from cache
+        run: |
+          if [[ -e /tmp/nix_store ]]; then
+            sudo rm -rf /nix
+            sudo mkdir -p /nix /nix/var/nix/db
+            sudo mv /tmp/nix_store /nix/store
+            sudo mv /tmp/nix_store_db /nix/var/nix/db/db.sqlite
+            sudo chown -R root:root /nix
+          fi
+
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v15
+        with:
+          extra_nix_config: |
+            keep-outputs = true
+
+      - run: nix build
+
+      - name: Check that flake.lock is uptodate
+        run: if ! git diff --exit-code -- flake.lock; then exit 1; fi
+
+      - name: Prepare the Nix store for caching
+        run: |
+          nix store gc
+          sudo systemctl stop nix-daemon
+          sudo mv /nix/store /tmp/nix_store
+          sudo mv /nix/var/nix/db/db.sqlite /tmp/nix_store_db

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,155 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mirage-opam-overlays": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661959605,
+        "narHash": "sha256-CPTuhYML3F4J58flfp3ZbMNhkRkVFKmBEYBZY5tnQwA=",
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
+        "rev": "05f1c1823d891ce4d8adab91f5db3ac51d86dc0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1663760840,
+        "narHash": "sha256-ym5Iycs5H4cOaLfE2/vC0tsLp8XuBJQIHGV8/uXSy8M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9bdbbaa634aa666eb6a27096bdcb991c59181244",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "opam-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "mirage-opam-overlays": "mirage-opam-overlays",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "opam-overlays": "opam-overlays",
+        "opam-repository": "opam-repository",
+        "opam2json": "opam2json"
+      },
+      "locked": {
+        "lastModified": 1665180241,
+        "narHash": "sha256-1VHXIFPy2B4q4hOWH3Koy6r8lWDvmroymMfCX0WQAVk=",
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "rev": "2d2543dd67464345418fd81d9800ebe56a6f6d0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "type": "github"
+      }
+    },
+    "opam-overlays": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654162756,
+        "narHash": "sha256-RV68fUK+O3zTx61iiHIoS0LvIk0E4voMp+0SwRg6G6c=",
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "rev": "c8f6ef0fc5272f254df4a971a47de7848cc1c8a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "type": "github"
+      }
+    },
+    "opam-repository": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661161626,
+        "narHash": "sha256-J3P+mXLwE2oEKTlMnx8sYRxwD/uNGSKM0AkAB7BNTxA=",
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "rev": "54e69ff0949a3aaec0d5e3d67898bb7f279ab09f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "type": "github"
+      }
+    },
+    "opam2json": {
+      "inputs": {
+        "nixpkgs": [
+          "opam-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1651529032,
+        "narHash": "sha256-fe8bm/V/4r2iNxgbitT2sXBqDHQ0GBSnSUSBg/1aXoI=",
+        "owner": "tweag",
+        "repo": "opam2json",
+        "rev": "e8e9f2fa86ef124b9f7b8db41d3d19471c1d8901",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam2json",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "opam-nix": "opam-nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -29,8 +29,10 @@
         nixosModules.albatross = { pkgs, ... }:
           let albatross = self.packages.${pkgs.system}.albatross;
           in {
-            imports =
-              [ (import packaging/nixos/albatross_service.nix albatross) ];
+            imports = [
+              (import packaging/nixos/albatross_service.nix albatross)
+              packaging/nixos/albatross_tls_endpoint.nix
+            ];
 
           };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  inputs.nixpkgs.url = "nixpkgs";
+  inputs.opam-nix = {
+    url = "github:tweag/opam-nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+    inputs.flake-utils.follows = "flake-utils";
+  };
+  inputs.flake-utils = {
+    url = "github:numtide/flake-utils";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, opam-nix, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system: {
+      legacyPackages = let
+        inherit (opam-nix.lib.${system}) buildOpamProject;
+        scope = buildOpamProject { } "albatross" ./. { ocaml-system = "*"; };
+
+      in scope.overrideScope' (self: super: {
+        # Prevent unnecessary dependencies on the resulting derivation
+        albatross = super.albatross.overrideAttrs (_: {
+          removeOcamlReferences = true;
+          doNixSupport = false;
+        });
+      });
+
+      defaultPackage = self.legacyPackages.${system}.albatross;
+
+    });
+}

--- a/packaging/nixos/albatross_service.nix
+++ b/packaging/nixos/albatross_service.nix
@@ -23,6 +23,11 @@ in {
       services.albatross = {
         enable = mkEnableOption "albatross";
 
+        cacert = mkOption {
+          description = "Signing certificate.";
+          type = path;
+        };
+
         forwardPorts = mkOption {
           description =
             "Forward ports to the NAT the unikernels are configured to use. Accept the same input as 'networking.nat.forwardPorts'.";

--- a/packaging/nixos/albatross_service.nix
+++ b/packaging/nixos/albatross_service.nix
@@ -1,0 +1,120 @@
+albatross_pkg:
+{ config, options, lib, pkgs, ... }:
+
+let
+  conf = config.services.albatross;
+
+  runtime_dir = "/run/albatross";
+  db_dir = "/var/lib/albatross";
+
+  solo5 = pkgs.solo5.overrideAttrs (_: { doCheck = false; });
+
+  setup_dirs = pkgs.writeShellScript "albatross-setup-dirs" ''
+    mkdir -p ${db_dir}
+    ln -sfT ${solo5}/bin/solo5-hvt ${db_dir}/solo5-hvt
+    mkdir -p ${runtime_dir}/fifo
+    chmod 2770 ${runtime_dir}/fifo
+    mkdir -p ${runtime_dir}/util
+  '';
+
+in {
+  options = with lib;
+    with types; {
+      services.albatross = {
+        enable = mkEnableOption "albatross";
+
+        forwardPorts = mkOption {
+          description =
+            "Forward ports to the NAT the unikernels are configured to use. Accept the same input as 'networking.nat.forwardPorts'.";
+          type = options.networking.nat.forwardPorts.type;
+        };
+
+        package = mkOption {
+          description = "Override the albatross package used by the service.";
+          type = package;
+          default = albatross_pkg;
+        };
+
+      };
+    };
+
+  config = lib.mkIf conf.enable {
+    systemd.services.albatross-console = {
+      description = "Albatross console daemon (albatross-console)";
+      requires = [ "albatross-console.socket" ];
+      after = [ "syslog.target" ];
+      serviceConfig = {
+        Type = "simple";
+        User = "albatross";
+        Group = "albatross";
+        ExecStart = ''
+          ${conf.package}/bin/albatross-console --systemd-socket-activation --tmpdir="${runtime_dir}"
+        '';
+        RestrictAddressFamilies = "AF_UNIX";
+      };
+    };
+
+    systemd.sockets.albatross-console = {
+      description = "Albatross console socket";
+      partOf = [ "albatross-console.service" ];
+      socketConfig = {
+        ListenStream = "${runtime_dir}/util/console.sock";
+        SocketUser = "albatross";
+        SocketMode = "0660";
+      };
+    };
+
+    # Running as root
+    systemd.services.albatrossd = {
+      description = "Albatross VMM daemon (albatrossd)";
+      requires = [ "albatross-console.socket" "albatrossd.socket" ];
+      after = [ "syslog.target" "albatross-console.service" "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        User = "root";
+        Group = "albatross";
+        ExecStart = ''
+          ${conf.package}/bin/albatrossd --systemd-socket-activation --tmpdir=${runtime_dir} --dbdir=${db_dir} -vv
+        '';
+        ExecStartPre = setup_dirs;
+        ProtectSystem = "full";
+        ProtectHome = true;
+        OOMScoreAdjust = "-1000";
+        IgnoreSIGPIPE = true;
+      };
+      path = with pkgs; [ iproute util-linux ];
+    };
+
+    systemd.sockets.albatrossd = {
+      description = "Albatross daemon socket";
+      partOf = [ "albatrossd.service" ];
+      socketConfig = {
+        ListenStream = "${runtime_dir}/util/vmmd.sock";
+        SocketGroup = "albatross";
+        SocketMode = "0660";
+      };
+    };
+
+    # User and group for albatross services
+    users.users.albatross.isNormalUser = true;
+    users.groups.albatross.members = [ "albatross" ];
+
+    # Network bridges
+    networking.bridges.service.interfaces = [ ];
+    networking.interfaces.service = {
+      ipv4.addresses = [{
+        address = "10.0.0.1";
+        prefixLength = 24;
+      }];
+    };
+
+    # Network interface
+    networking.nat = {
+      enable = true;
+      internalInterfaces = [ "service" ];
+      externalInterface = "eth0";
+      inherit (conf) forwardPorts;
+    };
+  };
+}

--- a/packaging/nixos/albatross_tls_endpoint.nix
+++ b/packaging/nixos/albatross_tls_endpoint.nix
@@ -1,0 +1,61 @@
+{ config, lib, pkgs, ... }:
+
+let
+  parent_conf = config.services.albatross;
+  conf = parent_conf.endpoint;
+  enabled = parent_conf.enable && conf.enable;
+  inherit (parent_conf) package cacert;
+
+in {
+  options = with lib;
+    with types; {
+      services.albatross.endpoint = {
+        enable = mkEnableOption "albatross tls endpoint";
+
+        port = mkOption {
+          type = port;
+          default = 1025;
+        };
+
+        cert = mkOption {
+          description =
+            "TLS certificate used to authenticate the endpoint. Should be signed by the certificate passed to 'services.albatross.ca'.";
+          type = path;
+        };
+
+        private_key = mkOption {
+          description = "Private key corresponding to the 'cert'.";
+          type = path;
+        };
+
+      };
+    };
+
+  config = lib.mkIf enabled {
+    systemd.services.albatross-tls-endpoint = {
+      description = "Albatross tls endpoint";
+      requires = [ "albatrossd.socket" "albatross-tls-endpoint.socket" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        User = "albatross";
+        Group = "albatross";
+        ExecStart = ''
+          ${package}/bin/albatross-tls-endpoint --systemd-socket-activation --tmpdir="%t/albatross/" ${cacert} ${conf.cert} ${conf.private_key}
+        '';
+      };
+    };
+
+    systemd.sockets.albatross-tls-endpoint = {
+      description = "Albatross tls endpoint listening for requests";
+      partOf = [ "albatross-tls-endpoint.service" ];
+      socketConfig = {
+        ListenStream = conf.port;
+        SocketUser = "albatross";
+        SocketMode = "0660";
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = [ conf.port ];
+  };
+}


### PR DESCRIPTION
The `flake.nix` file define a package for albatross as well as a nixos module for deploying it as systemd services.

The project is built with [opam-nix](https://github.com/tweag/opam-nix), which should ensure that the package definition don't get out of date (as long as `opam install` works).

The systemd units are taken from the existing `packaging/linux` with slight changes. The module also configures a NAT and a network bridge named `service`.

The TLS endpoint is placed in a separate module to make sure it is optional.

An example of use can be found here: https://github.com/Julow/albatross-nixos-example

A weakness of the module at the moment is that the TLS endpoint's private key is copied into the Nix store and available to all users.
