### PR TITLE
Use get_ifindex_by_name

### DIFF
--- a/stats/albatross_stats_pure.ml
+++ b/stats/albatross_stats_pure.ml
@@ -8,7 +8,7 @@ external sysconf_clock_tick : unit -> int = "vmmanage_sysconf_clock_tick"
 
 external sysctl_kinfo_proc : int -> Stats.rusage * Stats.kinfo_mem =
   "vmmanage_sysctl_kinfo_proc"
-external sysctl_ifcount : unit -> int = "vmmanage_sysctl_ifcount"
+external get_ifindex_by_name : string -> int = "vmmanage_get_ifindex_by_name"
 external sysctl_ifdata : int -> Stats.ifdata = "vmmanage_sysctl_ifdata"
 
 type vmctx
@@ -250,27 +250,14 @@ let tick gather_bhyve t =
   (t'', outs)
 
 let add_pid t vmid vmmdev pid nics =
-  match wrap sysctl_ifcount () with
-  | None ->
-    Logs.err (fun m -> m "sysctl ifcount failed for %d %a" pid pp_nics nics) ;
-    Error (`Msg "sysctl ifcount failed")
-  | Some max_nic ->
-    let rec go cnt acc max_nic id =
-      if max_nic > 0 && cnt > 0 then
-        ( Logs.debug (fun m -> m "Try to ifdata on %d" id) ;
-          match wrap sysctl_ifdata id with
-        | None ->
-          Logs.debug (fun m -> m "%d does not exists" id) ;
-          go cnt acc max_nic (succ id)
-        | Some ifd ->
-          Logs.debug (fun m -> m "Got ifdata from: %S" ifd.Stats.bridge) ;
-          match List.find_opt (fun (_, tap) -> String.equal tap ifd.Stats.bridge) nics with
-          | Some (bridge, tap) -> go (pred cnt) ((bridge, id, tap) :: acc) (pred max_nic) (succ id)
-          | None -> go cnt acc (pred max_nic) (succ id) )
-      else
-        List.rev acc
+    let nic_ids =
+      List.filter_map
+        (fun (bridge, tap) ->
+           match wrap get_ifindex_by_name tap with
+           | Some ifindex -> Some (bridge, ifindex, tap)
+           | None -> Logs.debug (fun m -> m "failed to get ifindex for: %S" tap); None)
+        nics
     in
-    let nic_ids = go (List.length nics) [] max_nic 1 in
     Logs.info (fun m -> m "adding %a %d %a" Name.pp vmid pid pp_nics nics) ;
     let pid_nic = IM.add pid (Error 4, vmmdev, nic_ids) t.pid_nic
     and vmid_pid, ret = Vmm_trie.insert vmid pid t.vmid_pid

--- a/stats/albatross_stats_stubs.c
+++ b/stats/albatross_stats_stubs.c
@@ -176,7 +176,7 @@ CAMLprim value vmmanage_get_ifindex_by_name (value name) {
   if (sysctl(name_ifcount, nitems(name_ifcount), &ifcount, &dlen, NULL, 0) != 0)
     uerror("sysctl", Nothing);
 
-  for (int idx = ifcount; idx > 0; idx--) {
+  for (int idx = ifcount; idx >= 0; idx--) {
     name_ifdata[0] = CTL_NET;
     name_ifdata[1] = PF_LINK;
     name_ifdata[2] = NETLINK_GENERIC;

--- a/stats/albatross_stats_stubs.c
+++ b/stats/albatross_stats_stubs.c
@@ -229,10 +229,14 @@ CAMLprim value vmmanage_sysctl_ifcount(value unit) {
   if (err < 0)
     uerror("nl_connect", Nothing);
   err = rtnl_link_alloc_cache(nl_sock, AF_UNSPEC, &link_cache);
-  if (err < 0)
+  if (err < 0) {
+    nl_close(nl_sock);
     uerror("rtnl_link_alloc_cache", Nothing);
+  }
+  long items = nl_cache_nitems(link_cache);
+  nl_close(nl_sock);
 
-  CAMLreturn(Val_long(nl_cache_nitems(link_cache)));
+  CAMLreturn(Val_long(items));
 }
 
 CAMLprim value vmmanage_sysctl_ifdata(value num) {
@@ -250,11 +254,15 @@ CAMLprim value vmmanage_sysctl_ifdata(value num) {
   if (err < 0)
     uerror("nl_connect", Nothing);
   err = rtnl_link_alloc_cache(nl_sock, AF_UNSPEC, &link_cache);
-  if (err < 0)
+  if (err < 0) {
+    nl_close(nl_sock);
     uerror("rtnl_link_alloc_cache", Nothing);
+  }
   link = rtnl_link_get(link_cache, Int_val(num));
-  if (link == NULL)
+  if (link == NULL) {
+    nl_close(nl_sock);
     uerror("rtnl_link_get", Nothing);
+  }
   res = caml_alloc(18, 0);
   Store_field(res, 0, caml_copy_string(rtnl_link_get_name(link)));
   Store_field(res, 1, Val32(rtnl_link_get_flags(link)));
@@ -274,6 +282,7 @@ CAMLprim value vmmanage_sysctl_ifdata(value num) {
   Store_field(res, 15, Val64(0));
   Store_field(res, 16, Val64(get_stat(link, RX_DROPPED)));
   Store_field(res, 17, Val64(get_stat(link, TX_DROPPED)));
+  nl_close(nl_sock);
   CAMLreturn(res);
 }
 

--- a/stats/albatross_stats_stubs.c
+++ b/stats/albatross_stats_stubs.c
@@ -13,6 +13,8 @@
 #include <sys/user.h>
 #include <net/if.h>
 
+#include <string.h>
+
 #define Val32 caml_copy_int32
 #define Val64 caml_copy_int64
 
@@ -170,7 +172,7 @@ CAMLprim value vmmanage_get_ifindex_by_name (value name) {
   name_ifcount[4] = IFMIB_IFCOUNT;
   dlen = sizeof(ifcount);
 
-  if (sysctl(name, nitems(name_ifcount), &ifcount, &dlen, NULL, 0) != 0)
+  if (sysctl(name_ifcount, nitems(name_ifcount), &ifcount, &dlen, NULL, 0) != 0)
     uerror("sysctl", Nothing);
 
   for (int idx = 1; idx <= ifcount; idx++) {
@@ -178,14 +180,15 @@ CAMLprim value vmmanage_get_ifindex_by_name (value name) {
     name_ifdata[1] = PF_LINK;
     name_ifdata[2] = NETLINK_GENERIC;
     name_ifdata[3] = IFMIB_IFDATA;
-    name_ifdata[4] = idx
+    name_ifdata[4] = idx;
     name_ifdata[5] = IFDATA_GENERAL;
     dlen = sizeof(data);
 
     if (sysctl(name_ifdata, nitems(name_ifdata), &data, &dlen, NULL, 0) != 0)
       uerror("sysctl", Nothing);
 
-    if (strcmp(data.ifmd_name, devname) = 0) {
+    if (strlen(devname) == strlen(data.ifmd_name) &&
+        strncmp(data.ifmd_name, devname, strlen(devname)) == 0) {
       CAMLreturn(Val_long(idx));
     }
   }

--- a/stats/albatross_stats_stubs.c
+++ b/stats/albatross_stats_stubs.c
@@ -32,6 +32,7 @@ CAMLprim value vmmanage_sysconf_clock_tick(value unit) {
 
 #ifdef __FreeBSD__
 #include <sys/sysctl.h>
+#include <sys/socket.h>
 #include <net/if_mib.h>
 #include <vm/vm.h>
 #include <machine/vmm.h>
@@ -156,47 +157,17 @@ CAMLprim value vmmanage_vmmapi_stats (value octx) {
 CAMLprim value vmmanage_get_ifindex_by_name (value name) {
   CAMLparam1(name);
   const char *devname;
-  int ifcount = 0;
-  size_t dlen = 0;
-  int name_ifcount[5];
-  int name_ifdata[6];
-  struct ifmibdata data;
+  int ifindex = 0;
 
   if (! caml_string_is_c_safe(name)) caml_raise_not_found();
 
   devname = String_val(name);
 
-  name_ifcount[0] = CTL_NET;
-  name_ifcount[1] = PF_LINK;
-  name_ifcount[2] = NETLINK_GENERIC;
-  name_ifcount[3] = IFMIB_SYSTEM;
-  name_ifcount[4] = IFMIB_IFCOUNT;
-  dlen = sizeof(ifcount);
+  ifindex = if_nametoindex(devname);
+  if (ifindex == 0)
+    caml_raise_not_found();
 
-  if (sysctl(name_ifcount, nitems(name_ifcount), &ifcount, &dlen, NULL, 0) != 0)
-    uerror("sysctl", Nothing);
-
-  for (int idx = ifcount; idx >= 0; idx--) {
-    name_ifdata[0] = CTL_NET;
-    name_ifdata[1] = PF_LINK;
-    name_ifdata[2] = NETLINK_GENERIC;
-    name_ifdata[3] = IFMIB_IFDATA;
-    name_ifdata[4] = idx;
-    name_ifdata[5] = IFDATA_GENERAL;
-    dlen = sizeof(data);
-
-    if (sysctl(name_ifdata, nitems(name_ifdata), &data, &dlen, NULL, 0) != 0) {
-      if (errno == ENOENT) continue;
-      uerror("sysctl", Nothing);
-    }
-
-    if (strlen(devname) == strlen(data.ifmd_name) &&
-        strncmp(data.ifmd_name, devname, strlen(devname)) == 0) {
-      CAMLreturn(Val_long(idx));
-    }
-  }
-
-  caml_raise_not_found();
+  CAMLreturn(Val_long(ifindex));
 }
 
 CAMLprim value vmmanage_sysctl_ifdata (value num) {
@@ -249,38 +220,15 @@ CAMLprim value vmmanage_sysctl_ifdata (value num) {
 CAMLprim value vmmanage_get_ifindex_by_name(value name) {
   CAMLparam1(name);
   const char *devname;
-  int err;
-  struct nl_sock *nl_sock;
-  struct nl_cache *link_cache;
-  struct rtnl_link *link;
   int ifindex;
 
   if (! caml_string_is_c_safe(name)) caml_raise_not_found();
+
   devname = String_val(name);
 
-  nl_sock = nl_socket_alloc();
-  if (nl_sock == 0)
-    uerror("nl_socket_alloc", Nothing);
-  err = nl_connect(nl_sock, NETLINK_ROUTE);
-  if (err < 0) {
-    nl_socket_free(nl_sock);
-    uerror("nl_connect", Nothing);
-  }
-  err = rtnl_link_alloc_cache(nl_sock, AF_UNSPEC, &link_cache);
-  nl_socket_free(nl_sock);
-  if (err < 0)
-    uerror("rtnl_link_alloc_cache", Nothing);
-
-  link = rtnl_link_get_by_name(link_cache, devname);
-  if (link == NULL) {
-    nl_cache_free(link_cache);
+  ifindex = if_nametoindex(devname);
+  if (ifindex == 0)
     caml_raise_not_found();
-  }
-  ifindex = rtnl_link_get_ifindex(link);
-  nl_cache_free(link_cache);
-  if (ifindex == 0) {
-    caml_raise_not_found();
-  }
 
   CAMLreturn(Val_long(ifindex));
 }


### PR DESCRIPTION
This is an alternative to #123 and #124 that expects from the C stubs a function `get_ifindex_by_name`. This simplifies the OCaml code, and allows us to use `rtnl_link_get_by_name` on Linux, and on FreeBSD the ifindex dance is moved to the C stub.