### PR TITLE
Remove includes that are not necessary

### DIFF
--- a/stats/albatross_stats_stubs.c
+++ b/stats/albatross_stats_stubs.c
@@ -13,9 +13,6 @@
 #include <sys/user.h>
 #include <net/if.h>
 
-#include <string.h>
-#include <errno.h>
-
 #define Val32 caml_copy_int32
 #define Val64 caml_copy_int64
 


### PR DESCRIPTION
They were introduced in a commit in #125 but were not removed when the code was changed. It builds on Linux.