### PR TITLE
Invert stats communication (stats is a client to albatross-daemon)

### DIFF
--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -432,14 +432,6 @@ let set_dbdir path =
   | Ok path -> Vmm_unix.set_dbdir path
   | Error `Msg m -> invalid_arg m
 
-let enable_stats =
-  let doc = "Connect to albatross-stats to report statistics" in
-  Arg.(value & flag & info [ "enable-stats" ] ~doc)
-
-let retry_connections =
-  let doc = "Number of retries when connecting to other daemons (log, console, stats etc). 0 aborts after one failure, -1 is unlimited retries." in
-  Arg.(value & opt int 2 & info [ "retry-connections" ] ~doc)
-
 let systemd_socket_activation =
   match uname with
   | FreeBSD | Darwin -> Term.const false

--- a/daemon/albatrossd.ml
+++ b/daemon/albatrossd.ml
@@ -8,11 +8,13 @@ open Lwt.Infix
 
 let state = ref Vmm_vmmd.empty
 
+let stats_fd = ref None
+
 let stub_data_out _ = Lwt.return_unit
 
 let create_lock = Lwt_mutex.create ()
 (* the global lock held during execution of create -- and also while
-   Vmm_vmmd.handle is getting called, and while communicating via log /
+   Vmm_vmmd.handle is getting called, and while communicating via
    console / stat socket communication. *)
 
 let rec create stat_out cons_out data_out name config =
@@ -70,7 +72,7 @@ let handle cons_out stat_out fd addr =
     Vmm_lwt.read_wire fd >>= function
     | Error _ ->
       Logs.err (fun m -> m "error while reading") ;
-      Lwt.return_unit
+      Lwt.return `Close
     | Ok (hdr, wire) ->
       let out wire' =
         (* TODO should we terminate the connection on write failure? *)
@@ -80,21 +82,31 @@ let handle cons_out stat_out fd addr =
                      (Vmm_commands.pp_wire ~verbose:false) (hdr, wire));
       Lwt_mutex.lock create_lock >>= fun () ->
       match Vmm_vmmd.handle_command !state (hdr, wire) with
-      | Error wire' -> Lwt_mutex.unlock create_lock; out wire'
+      | Error wire' ->
+        Lwt_mutex.unlock create_lock;
+        out wire' >|= fun () ->
+        `Close
       | Ok (state', next) ->
         state := state' ;
         match next with
-        | `Loop wire -> Lwt_mutex.unlock create_lock; out wire >>= loop
-        | `End wire -> Lwt_mutex.unlock create_lock; out wire
+        | `Loop wire ->
+          Lwt_mutex.unlock create_lock;
+          out wire >>= loop
+        | `End wire ->
+          Lwt_mutex.unlock create_lock;
+          out wire >|= fun () ->
+          `Close
         | `Create (id, vm) ->
           create stat_out cons_out out id vm >|= fun () ->
-          Lwt_mutex.unlock create_lock
+          Lwt_mutex.unlock create_lock;
+          `Close
         | `Wait (who, data) ->
           let state', task = Vmm_vmmd.register !state who Lwt.task in
           state := state';
           Lwt_mutex.unlock create_lock;
           task >>= fun r ->
-          out (data r)
+          out (data r) >|= fun () ->
+          `Close
         | `Wait_and_create (who, (id, vm)) ->
           let state', task = Vmm_vmmd.register !state who Lwt.task in
           state := state';
@@ -102,10 +114,22 @@ let handle cons_out stat_out fd addr =
           task >>= fun r ->
           Logs.info (fun m -> m "wait returned %a" pp_process_exit r);
           Lwt_mutex.with_lock create_lock (fun () ->
-              create stat_out cons_out out id vm)
+              create stat_out cons_out out id vm) >|= fun () ->
+          `Close
+        | `Replace_stats (wire, datas) ->
+          (Option.fold
+             ~none:Lwt.return_unit
+             ~some:(fun fd -> Vmm_lwt.safe_close fd)
+             !stats_fd) >>= fun () ->
+          stats_fd := Some fd;
+          out wire >>= fun () ->
+          Lwt_list.iter_s (stat_out "setting up stats") datas >|= fun () ->
+          Lwt_mutex.unlock create_lock;
+          `Retain
   in
-  loop () >>= fun () ->
-  Vmm_lwt.safe_close fd
+  loop () >>= function
+  | `Close -> Vmm_lwt.safe_close fd
+  | `Retain -> Lwt.return_unit
 
 let write_reply name fd txt (hdr, cmd) =
   Vmm_lwt.write_wire fd (hdr, cmd) >>= function
@@ -138,7 +162,7 @@ let write_reply name fd txt (hdr, cmd) =
 
 let m = conn_metrics "unix"
 
-let jump _ systemd influx tmpdir dbdir retries enable_stats =
+let jump _ systemd influx tmpdir dbdir =
   Sys.(set_signal sigpipe Signal_ignore);
   Albatross_cli.set_tmpdir tmpdir;
   Albatross_cli.set_dbdir dbdir;
@@ -150,24 +174,11 @@ let jump _ systemd influx tmpdir dbdir retries enable_stats =
   | Error (`Msg msg) -> Logs.err (fun m -> m "bailing out: %s" msg)
   | Ok old_unikernels ->
     Lwt_main.run
-      (let rec unix_connect ~retries s =
-         let path = socket_path s in
-         Vmm_lwt.connect Lwt_unix.PF_UNIX (Lwt_unix.ADDR_UNIX path) >>= function
-         | Some x -> Lwt.return x
-         | None when (retries <> 0) ->
-           Logs.err (fun m -> m "unable to connect to %a, retrying in 3 seconds"
-                        pp_socket s);
-           Lwt_unix.sleep 3.0 >>= fun () ->
-           unix_connect ~retries:(retries - 1) s
-         | None -> Lwt.fail_with (Fmt.str "cannot connect to %a" pp_socket s)
-       in
+      (let console_path = socket_path `Console in
+       (Vmm_lwt.connect Lwt_unix.PF_UNIX (Lwt_unix.ADDR_UNIX console_path) >|= function
+         | Some x -> x
+         | None -> failwith (Fmt.str "cannot connect to %a" pp_socket `Console)) >>= fun c ->
        init_influx "albatross" influx;
-       unix_connect ~retries `Console >>= fun c ->
-       (if enable_stats then
-          unix_connect ~retries `Stats >|= fun s ->
-          Some s
-        else
-          Lwt.return_none) >>= fun s ->
        let listen_socket () =
          if systemd then Vmm_lwt.systemd_socket ()
          else Vmm_lwt.service_socket `Vmmd
@@ -192,12 +203,19 @@ let jump _ systemd influx tmpdir dbdir retries enable_stats =
        Sys.(set_signal sigterm
               (Signal_handle (fun _ -> Lwt.async self_destruct)));
        let cons_out = write_reply "cons" c
-       and stat_out txt wire = match s with
+       and stat_out txt wire = match !stats_fd with
          | None ->
            Logs.info (fun m -> m "ignoring stat %s %a" txt
                          (Vmm_commands.pp_wire ~verbose:false) wire);
            Lwt.return_unit
-         | Some s -> write_reply "stat" s txt wire >|= fun _ -> ()
+         | Some s ->
+           Lwt.catch
+             (fun () -> write_reply "stat" s txt wire >|= fun _ -> ())
+             (fun e ->
+                Logs.err (fun m -> m "exception while writing to stats: %s"
+                             (Printexc.to_string e));
+                stats_fd := None;
+                Lwt.return_unit)
        in
        Lwt_list.iter_s (fun (name, config) ->
            Lwt_mutex.with_lock create_lock (fun () ->
@@ -223,7 +241,7 @@ open Cmdliner
 
 let cmd =
   let term =
-    Term.(const jump $ setup_log $ systemd_socket_activation $ influx $ tmpdir $ dbdir $ retry_connections $ enable_stats)
+    Term.(const jump $ setup_log $ systemd_socket_activation $ influx $ tmpdir $ dbdir)
   and info = Cmd.info "albatrossd" ~version:Albatross_cli.version
   in
   Cmd.v info term

--- a/flake.lock
+++ b/flake.lock
@@ -67,12 +67,18 @@
         "flake-utils": [
           "flake-utils"
         ],
-        "mirage-opam-overlays": "mirage-opam-overlays",
+        "mirage-opam-overlays": [
+          "mirage-opam-overlays"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ],
-        "opam-overlays": "opam-overlays",
-        "opam-repository": "opam-repository",
+        "opam-overlays": [
+          "opam-overlays"
+        ],
+        "opam-repository": [
+          "opam-repository"
+        ],
         "opam2json": "opam2json"
       },
       "locked": {
@@ -92,11 +98,11 @@
     "opam-overlays": {
       "flake": false,
       "locked": {
-        "lastModified": 1654162756,
-        "narHash": "sha256-RV68fUK+O3zTx61iiHIoS0LvIk0E4voMp+0SwRg6G6c=",
+        "lastModified": 1667503498,
+        "narHash": "sha256-s1PgYmuWJABbb4J/XyEvZh1s9i8Jqg6GwXVsUsW8uA4=",
         "owner": "dune-universe",
         "repo": "opam-overlays",
-        "rev": "c8f6ef0fc5272f254df4a971a47de7848cc1c8a4",
+        "rev": "d97e352e87fc628e1b00e9649f0f552865be791a",
         "type": "github"
       },
       "original": {
@@ -108,11 +114,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1661161626,
-        "narHash": "sha256-J3P+mXLwE2oEKTlMnx8sYRxwD/uNGSKM0AkAB7BNTxA=",
+        "lastModified": 1667574627,
+        "narHash": "sha256-FDrvEG9t7SJ/1AIUlmBNYQQrlLbpKt7y+6Bt8K587DA=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "54e69ff0949a3aaec0d5e3d67898bb7f279ab09f",
+        "rev": "3117254d1669a3597b7ed8f51f7ffb0e523e5fd6",
         "type": "github"
       },
       "original": {
@@ -145,8 +151,11 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "mirage-opam-overlays": "mirage-opam-overlays",
         "nixpkgs": "nixpkgs",
-        "opam-nix": "opam-nix"
+        "opam-nix": "opam-nix",
+        "opam-overlays": "opam-overlays",
+        "opam-repository": "opam-repository"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,13 +4,28 @@
     url = "github:tweag/opam-nix";
     inputs.nixpkgs.follows = "nixpkgs";
     inputs.flake-utils.follows = "flake-utils";
+    inputs.opam-repository.follows = "opam-repository";
+    inputs.opam-overlays.follows = "opam-overlays";
+    inputs.mirage-opam-overlays.follows = "mirage-opam-overlays";
   };
   inputs.flake-utils = {
     url = "github:numtide/flake-utils";
     inputs.nixpkgs.follows = "nixpkgs";
   };
+  inputs.opam-repository = {
+    url = "github:ocaml/opam-repository";
+    flake = false;
+  };
+  inputs.opam-overlays = {
+    url = "github:dune-universe/opam-overlays";
+    flake = false;
+  };
+  inputs.mirage-opam-overlays = {
+    url = "github:dune-universe/mirage-opam-overlays";
+    flake = false;
+  };
 
-  outputs = { self, nixpkgs, opam-nix, flake-utils }:
+  outputs = { self, nixpkgs, opam-nix, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         inherit (opam-nix.lib.${system}) buildOpamProject;

--- a/src/vmm_asn.ml
+++ b/src/vmm_asn.ml
@@ -264,13 +264,15 @@ let stats_cmd =
     | `C1 (name, pid, taps) -> `Stats_add (name, pid, taps)
     | `C2 () -> `Stats_remove
     | `C3 () -> `Stats_subscribe
+    | `C4 () -> `Stats_initial
   and g = function
     | `Stats_add (name, pid, taps) -> `C1 (name, pid, taps)
     | `Stats_remove -> `C2 ()
     | `Stats_subscribe -> `C3 ()
+    | `Stats_initial -> `C4 ()
   in
   Asn.S.map f g @@
-  Asn.S.(choice3
+  Asn.S.(choice4
            (my_explicit 0 ~label:"add"
               (sequence3
                  (required ~label:"vmmdev" utf8_string)
@@ -281,7 +283,8 @@ let stats_cmd =
                           (required ~label:"bridge" utf8_string)
                           (required ~label:"tap" utf8_string))))))
            (my_explicit 1 ~label:"remove" null)
-           (my_explicit 2 ~label:"subscribe" null))
+           (my_explicit 2 ~label:"subscribe" null)
+           (my_explicit 3 ~label:"initial" null))
 
 let old_name =
   let f list =

--- a/src/vmm_commands.ml
+++ b/src/vmm_commands.ml
@@ -42,6 +42,7 @@ type stats_cmd = [
   | `Stats_add of string * int * (string * string) list
   | `Stats_remove
   | `Stats_subscribe
+  | `Stats_initial
 ]
 
 let pp_stats_cmd ppf = function
@@ -50,6 +51,7 @@ let pp_stats_cmd ppf = function
       Fmt.(list ~sep:(any ", ") (pair ~sep:(any ": ") string string)) taps
   | `Stats_remove -> Fmt.string ppf "stat remove"
   | `Stats_subscribe -> Fmt.string ppf "stat subscribe"
+  | `Stats_initial -> Fmt.string ppf "stat initial"
 
 type unikernel_cmd = [
   | `Unikernel_info

--- a/src/vmm_commands.mli
+++ b/src/vmm_commands.mli
@@ -26,6 +26,7 @@ type stats_cmd = [
   | `Stats_add of string * int * (string * string) list
   | `Stats_remove
   | `Stats_subscribe
+  | `Stats_initial
 ]
 
 type unikernel_cmd = [

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -447,7 +447,7 @@ let handle_stats_initial t stats_counter =
         (t, out :: acc))
       (t, []) unikernels
   in
-  Ok (t, `Replace_stats (`Success (`String "registered stat"), data))
+  Ok (t, `Replace_stats (`Success `Empty, data))
 
 let handle_command t (header, payload) =
   let msg_to_err = function

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -438,6 +438,17 @@ let handle_block_cmd t id = function
     in
     Ok (t, `End (`Success (`Block_devices blocks)))
 
+let handle_stats_initial t stats_counter =
+  let t = { t with stats_counter = Int64.succ stats_counter } in
+  let t, data =
+    let unikernels = Vmm_trie.all t.resources.Vmm_resources.unikernels in
+    List.fold_left (fun (t, acc) (name, vm) ->
+        let t, out = setup_stats t name vm in
+        (t, out :: acc))
+      (t, []) unikernels
+  in
+  Ok (t, `Replace_stats (`Success (`String "registered stat"), data))
+
 let handle_command t (header, payload) =
   let msg_to_err = function
     | Ok x -> Ok x
@@ -451,6 +462,8 @@ let handle_command t (header, payload) =
     | `Command (`Policy_cmd pc) -> handle_policy_cmd t id pc
     | `Command (`Unikernel_cmd vc) -> handle_unikernel_cmd t id vc
     | `Command (`Block_cmd bc) -> handle_block_cmd t id bc
+    | `Command (`Stats_cmd `Stats_initial) ->
+      handle_stats_initial t header.Vmm_commands.sequence
     | _ ->
       Logs.err (fun m -> m "ignoring %a"
                    (Vmm_commands.pp_wire ~verbose:false) (header, payload)) ;

--- a/src/vmm_vmmd.mli
+++ b/src/vmm_vmmd.mli
@@ -33,7 +33,8 @@ val handle_command : 'a t -> Vmm_commands.wire ->
    | `Loop of Vmm_commands.res
    | `End of Vmm_commands.res
    | `Wait of Name.t * (process_exit -> Vmm_commands.res)
-   | `Wait_and_create of Name.t * (Name.t * Unikernel.config) ],
+   | `Wait_and_create of Name.t * (Name.t * Unikernel.config)
+   | `Replace_stats of Vmm_commands.res * Vmm_commands.wire list ],
    Vmm_commands.res) result
 
 val killall : 'a t -> (unit -> 'b * 'a) -> 'a t * 'b list

--- a/stats/albatross_stats.ml
+++ b/stats/albatross_stats.ml
@@ -91,7 +91,7 @@ let jump _ systemd interval gather_bhyve influx tmpdir =
            vmmd_connect ~wait:true ()
          | Ok () ->
            Vmm_lwt.read_wire s >>= function
-           | Ok (h, `Success _) when Int64.equal h.sequence header.sequence ->
+           | Ok (h, `Success `Empty) when Int64.equal h.sequence header.sequence ->
              handle s addr >>= fun () ->
              t := empty ();
              vmmd_connect ~wait:true ()

--- a/stats/albatross_stats_pure.ml
+++ b/stats/albatross_stats_pure.ml
@@ -271,6 +271,9 @@ let handle t socket (hdr, wire) =
     begin
       let id = hdr.Vmm_commands.name in
       match cmd with
+      | `Stats_initial ->
+        Logs.warn (fun m -> m "unexpected message initial");
+        Error (`Msg "unexpected message initial")
       | `Stats_add (vmmdev, pid, taps) ->
         let* t = add_pid t id vmmdev pid taps in
         Ok (t, None, "added")


### PR DESCRIPTION
Previously, albatross-daemon was eventually connecting to stats (with --enable-stats and --retries). This did not allow to setup stats at a later point. This also did not allow stats to crash.

Now stats is connecting at startup to albatross-daemon (and whenever that fails, reconnects). Once initially connected, albatross-daemon will dump all running unikernel information so that stats can start collecting. This allows the stats daemon to be independently restarted, or surviving an albatross-daemon.