### PR TITLE
Revert "remove statistics commands from clients"

### DIFF
--- a/client/albatross_client_bistro.ml
+++ b/client/albatross_client_bistro.ml
@@ -135,6 +135,9 @@ let create _ endp cert key ca key_type bits name dbdir force image cpuid memory 
 let console _ endp cert key ca key_type bits name since count =
   jump endp cert key ca key_type bits name (`Console_cmd (`Console_subscribe (Albatross_cli.since_count since count)))
 
+let stats _ endp cert key ca key_type bits name =
+  jump endp cert key ca key_type bits name (`Stats_cmd `Stats_subscribe)
+
 let block_info _ endp cert key ca key_type bits block_name =
   jump endp cert key ca key_type bits block_name (`Block_cmd `Block_info)
 
@@ -302,6 +305,18 @@ let console_cmd =
   in
   Cmd.v info term
 
+let stats_cmd =
+  let doc = "statistics of VMs" in
+  let man =
+    [`S "DESCRIPTION";
+     `P "Shows statistics of VMs."]
+  in
+  let term =
+    Term.(term_result (const stats $ setup_log $ destination $ ca_cert $ ca_key $ server_ca $ pub_key_type $ key_bits $ opt_vm_name))
+  and info = Cmd.info "stats" ~doc ~man ~exits
+  in
+  Cmd.v info term
+
 let block_info_cmd =
   let doc = "Information about block devices" in
   let man =
@@ -385,7 +400,7 @@ let cmds = [ policy_cmd ; remove_policy_cmd ; add_policy_cmd ;
              info_cmd ; get_cmd ; destroy_cmd ; create_cmd ;
              block_info_cmd ; block_create_cmd ; block_destroy_cmd ;
              block_set_cmd ; block_dump_cmd ;
-             console_cmd ;
+             console_cmd ; stats_cmd ;
              update_cmd ]
 
 let () =

--- a/client/albatross_client_local.ml
+++ b/client/albatross_client_local.ml
@@ -90,6 +90,15 @@ let create _ opt_socket dbdir force name image cpuid memory argv block network c
 let console _ opt_socket name since count =
   jump opt_socket name (`Console_cmd (`Console_subscribe (Albatross_cli.since_count since count)))
 
+let stats_add _ opt_socket name vmmdev pid bridge_taps =
+  jump opt_socket name (`Stats_cmd (`Stats_add (vmmdev, pid, bridge_taps)))
+
+let stats_remove _ opt_socket name =
+  jump opt_socket name (`Stats_cmd `Stats_remove)
+
+let stats_subscribe _ opt_socket name =
+  jump opt_socket name (`Stats_cmd `Stats_subscribe)
+
 let block_info _ opt_socket block_name =
   jump opt_socket block_name (`Block_cmd `Block_info)
 
@@ -276,6 +285,42 @@ let console_cmd =
   in
   Cmd.v info term
 
+let stats_subscribe_cmd =
+  let doc = "statistics of VMs" in
+  let man =
+    [`S "DESCRIPTION";
+     `P "Shows statistics of VMs."]
+  in
+  let term =
+    Term.(term_result (const stats_subscribe $ setup_log $ socket $ opt_vm_name $ tmpdir))
+  and info = Cmd.info "stats" ~doc ~man ~exits
+  in
+  Cmd.v info term
+
+let stats_remove_cmd =
+  let doc = "remove statistics of VM" in
+  let man =
+    [`S "DESCRIPTION";
+     `P "Removes statistics of VM."]
+  in
+  let term =
+    Term.(term_result (const stats_remove $ setup_log $ socket $ opt_vm_name $ tmpdir))
+  and info = Cmd.info "stats_remove" ~doc ~man ~exits
+  in
+  Cmd.v info term
+
+let stats_add_cmd =
+  let doc = "Add VM to statistics gathering" in
+  let man =
+    [`S "DESCRIPTION";
+     `P "Add VM to statistics gathering."]
+  in
+  let term =
+    Term.(term_result (const stats_add $ setup_log $ socket $ opt_vm_name $ vmm_dev_req0 $ pid_req1 $ bridge_taps $ tmpdir))
+  and info = Cmd.info "stats_add" ~doc ~man ~exits
+  in
+  Cmd.v info term
+
 let block_info_cmd =
   let doc = "Information about block devices" in
   let man =
@@ -360,6 +405,7 @@ let cmds = [ policy_cmd ; remove_policy_cmd ; add_policy_cmd ;
              block_info_cmd ; block_create_cmd ; block_destroy_cmd ;
              block_set_cmd ; block_dump_cmd ;
              console_cmd ;
+             stats_subscribe_cmd ; stats_add_cmd ; stats_remove_cmd ;
              update_cmd ]
 
 let () =

--- a/provision/albatross_provision_request.ml
+++ b/provision/albatross_provision_request.ml
@@ -49,6 +49,9 @@ let console _ key_type bits name since count =
   let cmd = `Console_subscribe (Albatross_cli.since_count since count) in
   jump key_type bits name (`Console_cmd cmd)
 
+let stats _ key_type bits name =
+  jump key_type bits name (`Stats_cmd `Stats_subscribe)
+
 let block_info _ key_type bits block_name =
   jump key_type bits block_name (`Block_cmd `Block_info)
 
@@ -176,6 +179,18 @@ let console_cmd =
   in
   Cmd.v info term
 
+let stats_cmd =
+  let doc = "statistics of VMs" in
+  let man =
+    [`S "DESCRIPTION";
+     `P "Shows statistics of VMs."]
+  in
+  let term =
+    Term.(term_result (const stats $ setup_log $ pub_key_type $ key_bits $ opt_vm_name))
+  and info = Cmd.info "stats" ~doc ~man
+  in
+  Cmd.v info term
+
 let block_info_cmd =
   let doc = "Information about block devices" in
   let man =
@@ -247,7 +262,7 @@ let cmds = [ policy_cmd ; remove_policy_cmd ; add_policy_cmd ;
              info_cmd ; get_cmd ; destroy_cmd ; create_cmd ;
              block_info_cmd ; block_create_cmd ; block_destroy_cmd ;
              block_set_cmd ; block_dump_cmd ;
-             console_cmd ]
+             console_cmd ; stats_cmd ]
 
 let () =
   let doc = "Albatross provisioning request" in

--- a/tls/vmm_tls.ml
+++ b/tls/vmm_tls.ml
@@ -95,6 +95,7 @@ let handle chain =
     (* we only allow some commands via certificate *)
     match wire with
     | `Console_cmd (`Console_subscribe _)
+    | `Stats_cmd `Stats_subscribe
     | `Unikernel_cmd _
     | `Policy_cmd `Policy_info
     | `Block_cmd _ -> Ok (name, policies, v, wire)


### PR DESCRIPTION
This reverts commit 350ba03e1c95523da39f5a856c502f288adf779a.

I think #129 tracks if we want to merge influx and stats, but removing the functionality to track (add/subscribe) stats with a client was slightly premature.