### PR TITLE
More precise debian dependencies

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/roburio/albatross
 Vcs-Browser: https://github.com/roburio/albatross
 Vcs-Git: https://github.com/roburio/albatross.git
 Architecture: all
-Depends: libgmp10, libnl-3-dev, libnl-route-3-dev
+Depends: libgmp10, libnl-3-200, libnl-route-3-200
 Description: Albatross - orchestrate and manage MirageOS unikernels with Solo5
   The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
   unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed


### PR DESCRIPTION
Follow-up of #141.

In [Debian](https://packages.debian.org/search?keywords=libnl&searchon=names&suite=all&section=all) it's called libnl-3-200 from oldoldstable through unstable.

In [Ubuntu](https://packages.ubuntu.com/search?suite=all&searchon=names&keywords=libnl) it's as well called libnl-3-200 from 18.04 through 22.04LTS (and kinetic which I assume is the next release??).

I think it is safe to assume it's called libnl-3-200 in the relevant debian-derived distributions.