### PR TITLE
add restart command, split unix parts into a sublibrary

### DIFF
--- a/client/albatross_client_bistro.ml
+++ b/client/albatross_client_bistro.ml
@@ -132,6 +132,9 @@ let create _ endp cert key ca key_type bits name dbdir force image cpuid memory 
   | Ok cmd -> jump endp cert key ca key_type bits name (`Unikernel_cmd cmd)
   | Error (`Msg msg) -> failwith msg
 
+let restart _ endp cert key ca key_type bits name =
+  jump endp cert key ca key_type bits name (`Unikernel_cmd `Unikernel_restart)
+
 let console _ endp cert key ca key_type bits name since count =
   jump endp cert key ca key_type bits name (`Console_cmd (`Console_subscribe (Albatross_cli.since_count since count)))
 
@@ -210,14 +213,26 @@ let destination =
   Arg.(value & opt host_port ("localhost", 1025) & info [ "d" ; "destination" ] ~doc ~docv:"HOST:PORT")
 
 let destroy_cmd =
-  let doc = "destroys a virtual machine" in
+  let doc = "destroys a unikernel" in
   let man =
     [`S "DESCRIPTION";
-     `P "Destroy a virtual machine."]
+     `P "Destroy a unikernel."]
   in
   let term =
     Term.(term_result (const destroy $ setup_log $ destination $ ca_cert $ ca_key $ server_ca $ pub_key_type $ key_bits $ vm_name))
   and info = Cmd.info "destroy" ~doc ~man ~exits
+  in
+  Cmd.v info term
+
+let restart_cmd =
+  let doc = "restarts a unikernel" in
+  let man =
+    [`S "DESCRIPTION";
+     `P "Destroy a unikernel."]
+  in
+  let term =
+    Term.(term_result (const restart $ setup_log $ destination $ ca_cert $ ca_key $ server_ca $ pub_key_type $ key_bits $ vm_name))
+  and info = Cmd.info "restart" ~doc ~man ~exits
   in
   Cmd.v info term
 
@@ -282,10 +297,10 @@ let add_policy_cmd =
   Cmd.v info term
 
 let create_cmd =
-  let doc = "creates a virtual machine" in
+  let doc = "creates a unikernel" in
   let man =
     [`S "DESCRIPTION";
-     `P "Creates a virtual machine."]
+     `P "Creates a unikernel."]
   in
   let term =
     Term.(term_result (const create $ setup_log $ destination $ ca_cert $ ca_key $ server_ca $ pub_key_type $ key_bits $ vm_name $ dbdir $ force $ image $ cpu $ vm_mem $ args $ block $ net $ compress_level 9 $ restart_on_fail $ exit_code))
@@ -397,7 +412,7 @@ let help_cmd =
   Term.(ret (const help $ setup_log $ destination $ Arg.man_format $ Term.choice_names $ topic))
 
 let cmds = [ policy_cmd ; remove_policy_cmd ; add_policy_cmd ;
-             info_cmd ; get_cmd ; destroy_cmd ; create_cmd ;
+             info_cmd ; get_cmd ; destroy_cmd ; create_cmd ; restart_cmd ;
              block_info_cmd ; block_create_cmd ; block_destroy_cmd ;
              block_set_cmd ; block_dump_cmd ;
              console_cmd ; stats_cmd ;

--- a/command-line/albatross_cli.ml
+++ b/command-line/albatross_cli.ml
@@ -192,11 +192,11 @@ let label_c =
      Fmt.string)
 
 let opt_path =
-  let doc = "path to virtual machines." in
+  let doc = "path to unikernels." in
   Arg.(value & opt label_c "." & info [ "p" ; "path"] ~doc)
 
 let path =
-  let doc = "path to virtual machines." in
+  let doc = "path to unikernels." in
   Arg.(required & pos 0 (some label_c) None & info [] ~doc ~docv:"PATH")
 
 let bridge_tap_c =
@@ -221,7 +221,7 @@ let vmm_dev_req0 =
   Arg.(required & pos 0 (some string) None & info [] ~doc ~docv:"VMMDEV")
 
 let opt_vm_name =
-  let doc = "name of virtual machine." in
+  let doc = "name of unikernel." in
   Arg.(value & opt label_c "." & info [ "n" ; "name"] ~doc)
 
 let uri_c =
@@ -260,11 +260,11 @@ let vms =
   Arg.(required & pos 1 (some int) None & info [] ~doc ~docv:"VMS")
 
 let image =
-  let doc = "File of virtual machine image." in
+  let doc = "File of unikernel image." in
   Arg.(required & pos 1 (some file) None & info [] ~doc ~docv:"IMAGE")
 
 let vm_name =
-  let doc = "Name virtual machine." in
+  let doc = "Name unikernel." in
   Arg.(required & pos 0 (some label_c) None & info [] ~doc ~docv:"VM")
 
 let block_name =

--- a/command-line/dune
+++ b/command-line/dune
@@ -3,9 +3,9 @@
  (public_name albatross.cli)
  (wrapped false)
  (modules albatross_cli)
- (libraries checkseum.c albatross lwt.unix cmdliner logs.fmt logs.cli fmt
-   fmt.cli fmt.tty ipaddr.unix metrics metrics-lwt metrics-influx
-   metrics-rusage x509))
+ (libraries checkseum.c albatross albatross.unix lwt.unix cmdliner logs.fmt
+   logs.cli fmt fmt.cli fmt.tty ipaddr.unix metrics metrics-lwt metrics-influx
+   ptime.clock.os metrics-rusage x509))
 
 (library
  (name albatross_client_update)

--- a/daemon/albatross_influx.ml
+++ b/daemon/albatross_influx.ml
@@ -302,7 +302,7 @@ let drop_label =
 let vm_c = Arg.conv (Name.of_string, Name.pp)
 
 let opt_vm_name =
-  let doc = "name of virtual machine." in
+  let doc = "name of unikernel." in
   Arg.(value & opt vm_c Name.root & info [ "n" ; "name"] ~doc)
 
 let cmd =

--- a/provision/albatross_provision_request.ml
+++ b/provision/albatross_provision_request.ml
@@ -45,6 +45,9 @@ let create _ key_type bits name force image cpuid memory argv block network comp
   | Ok cmd -> jump key_type bits name (`Unikernel_cmd cmd)
   | Error (`Msg msg) -> Error (`Msg msg)
 
+let restart _ key_type bits name =
+  jump key_type bits name (`Unikernel_cmd `Unikernel_restart)
+
 let console _ key_type bits name since count =
   let cmd = `Console_subscribe (Albatross_cli.since_count since count) in
   jump key_type bits name (`Console_cmd cmd)
@@ -84,14 +87,26 @@ open Cmdliner
 open Albatross_cli
 
 let destroy_cmd =
-  let doc = "destroys a virtual machine" in
+  let doc = "destroys a unikernel" in
   let man =
     [`S "DESCRIPTION";
-     `P "Destroy a virtual machine."]
+     `P "Destroy a unikernel."]
   in
   let term =
     Term.(term_result (const destroy $ setup_log $ pub_key_type $ key_bits $ vm_name))
   and info = Cmd.info "destroy" ~doc ~man
+  in
+  Cmd.v info term
+
+let restart_cmd =
+  let doc = "restarts a unikernel" in
+  let man =
+    [`S "DESCRIPTION";
+     `P "Restart a unikernel."]
+  in
+  let term =
+    Term.(term_result (const restart $ setup_log $ pub_key_type $ key_bits $ vm_name))
+  and info = Cmd.info "restart" ~doc ~man
   in
   Cmd.v info term
 
@@ -156,10 +171,10 @@ let add_policy_cmd =
   Cmd.v info term
 
 let create_cmd =
-  let doc = "creates a virtual machine" in
+  let doc = "creates a unikernel" in
   let man =
     [`S "DESCRIPTION";
-     `P "Creates a virtual machine."]
+     `P "Creates a unikernel."]
   in
   let term =
     Term.(term_result (const create $ setup_log $ pub_key_type $ key_bits $ vm_name $ force $ image $ cpu $ vm_mem $ args $ block $ net $ compress_level 9 $ restart_on_fail $ exit_code))
@@ -259,7 +274,7 @@ let help_cmd =
   Term.(ret (const help $ setup_log $ Arg.man_format $ Term.choice_names $ topic))
 
 let cmds = [ policy_cmd ; remove_policy_cmd ; add_policy_cmd ;
-             info_cmd ; get_cmd ; destroy_cmd ; create_cmd ;
+             info_cmd ; get_cmd ; destroy_cmd ; create_cmd ; restart_cmd ;
              block_info_cmd ; block_create_cmd ; block_destroy_cmd ;
              block_set_cmd ; block_dump_cmd ;
              console_cmd ; stats_cmd ]

--- a/src/dune
+++ b/src/dune
@@ -4,6 +4,14 @@
  (instrumentation
   (backend bisect_ppx))
  (wrapped false)
- (libraries logs ipaddr ipaddr.unix bos ptime duration cstruct bigstringaf
-   decompress.de decompress.zl lwt lwt.unix ptime.clock.os asn1-combinators
-   metrics mirage-crypto hex solo5-elftool))
+ (modules vmm_core vmm_commands vmm_compress vmm_trie vmm_trie vmm_ring vmm_asn vmm_resources)
+ (libraries logs ipaddr ptime duration cstruct bigstringaf
+   decompress.de decompress.zl asn1-combinators fpath
+   metrics mirage-crypto hex))
+
+(library
+ (name albatross_unix)
+ (public_name albatross.unix)
+ (wrapped false)
+ (modules vmm_unix vmm_lwt vmm_vmmd)
+ (libraries albatross ipaddr.unix bos solo5-elftool lwt lwt.unix))

--- a/src/vmm_asn.ml
+++ b/src/vmm_asn.ml
@@ -307,7 +307,7 @@ let name =
 let typ =
   let f = function
     | `C1 () -> `Solo5
-    | `C2 () -> assert false
+    | `C2 () -> Asn.S.parse_error "typ not yet supported"
   and g = function
     | `Solo5 -> `C1 ()
   in
@@ -482,6 +482,8 @@ let unikernel_cmd =
     | `C2 `C4 vm -> `Unikernel_create vm
     | `C2 `C5 vm -> `Unikernel_force_create vm
     | `C2 `C6 level -> `Unikernel_get level
+    | `C3 `C1 () -> `Unikernel_restart
+    | `C3 `C2 () -> Asn.S.parse_error "unikernel command not yet supported"
   and g = function
     | `Old_unikernel_info -> `C1 (`C1 ())
     | `Unikernel_create vm -> `C2 (`C4 vm)
@@ -490,9 +492,10 @@ let unikernel_cmd =
     | `Old_unikernel_get -> `C2 (`C1 ())
     | `Unikernel_info -> `C2 (`C2 ())
     | `Unikernel_get level -> `C2 (`C6 level)
+    | `Unikernel_restart -> `C3 (`C1 ())
   in
   Asn.S.map f g @@
-  Asn.S.(choice2
+  Asn.S.(choice3
           (choice6
              (my_explicit 0 ~label:"info-OLD" null)
              (my_explicit 1 ~label:"create-OLD1" v1_unikernel_config)
@@ -506,7 +509,10 @@ let unikernel_cmd =
              (my_explicit 8 ~label:"get-OLD2" null)
              (my_explicit 9 ~label:"create" unikernel_config)
              (my_explicit 10 ~label:"force-create" unikernel_config)
-             (my_explicit 11 ~label:"get" int)))
+             (my_explicit 11 ~label:"get" int))
+          (choice2
+             (my_explicit 12 ~label:"restart" null)
+             (my_explicit 13 ~label:"placeholder" null)))
 
 let policy_cmd =
   let f = function

--- a/src/vmm_commands.ml
+++ b/src/vmm_commands.ml
@@ -57,6 +57,7 @@ type unikernel_cmd = [
   | `Unikernel_info
   | `Unikernel_create of Unikernel.config
   | `Unikernel_force_create of Unikernel.config
+  | `Unikernel_restart
   | `Unikernel_destroy
   | `Unikernel_get of int
   | `Old_unikernel_info
@@ -73,6 +74,7 @@ let pp_unikernel_cmd ~verbose ppf = function
     Fmt.pf ppf "vm force create %a"
       (if verbose then Unikernel.pp_config_with_argv else Unikernel.pp_config)
       config
+  | `Unikernel_restart -> Fmt.string ppf "unikernel restart"
   | `Unikernel_destroy -> Fmt.string ppf "unikernel destroy"
   | `Unikernel_get level -> Fmt.pf ppf "unikernel get compress level %d" level
   | `Old_unikernel_info -> Fmt.string ppf "old unikernel info"

--- a/src/vmm_commands.mli
+++ b/src/vmm_commands.mli
@@ -33,6 +33,7 @@ type unikernel_cmd = [
   | `Unikernel_info
   | `Unikernel_create of Unikernel.config
   | `Unikernel_force_create of Unikernel.config
+  | `Unikernel_restart
   | `Unikernel_destroy
   | `Unikernel_get of int
   | `Old_unikernel_info

--- a/src/vmm_core.ml
+++ b/src/vmm_core.ml
@@ -303,7 +303,7 @@ module Unikernel = struct
 
   type t = {
     config : config ;
-    cmd : Bos.Cmd.t ;
+    cmd : string array ;
     pid : int ;
     taps : string list ;
     digest : Cstruct.t ;
@@ -315,7 +315,7 @@ module Unikernel = struct
       vm.pid
       Fmt.(list ~sep:(any ", ") string) vm.taps
       Fmt.(list ~sep:(any ", ") pp_block) vm.config.block_devices
-      Bos.Cmd.pp vm.cmd
+      Fmt.(array ~sep:(any " ") string) vm.cmd
       hex_digest
 
   type info = {

--- a/src/vmm_core.mli
+++ b/src/vmm_core.mli
@@ -119,7 +119,7 @@ module Unikernel : sig
 
   type t = {
     config : config;
-    cmd : Bos.Cmd.t;
+    cmd : string array;
     pid : int;
     taps : string list;
     digest : Cstruct.t;

--- a/src/vmm_unix.ml
+++ b/src/vmm_unix.ml
@@ -381,7 +381,7 @@ let exec name (config : Unikernel.config) bridge_taps blocks digest =
        process and don't really need it here anymore... *)
     close_no_err stdout ;
     let taps = List.map (fun (_,tap,_) -> tap) bridge_taps in
-    Ok Unikernel.{ config ; cmd ; pid ; taps ; digest }
+    Ok Unikernel.{ config ; cmd = line ; pid ; taps ; digest }
   with
     Unix.Unix_error (e, _, _) ->
     close_no_err stdout;

--- a/src/vmm_vmmd.ml
+++ b/src/vmm_vmmd.ml
@@ -331,6 +331,13 @@ let handle_unikernel_cmd t id = function
          | () -> ());
         Ok (t, `Wait_and_create (id, (id, vm_config)))
     end
+  | `Unikernel_restart ->
+    begin
+      match Vmm_resources.find_vm t.resources id with
+      | None -> stop_create t id
+      | Some vm ->
+        Ok (t, `Wait_and_create (id, (id, vm.Unikernel.config)))
+    end
   | `Unikernel_destroy ->
     match Vmm_resources.find_vm t.resources id with
     | None -> stop_create t id

--- a/stats/dune
+++ b/stats/dune
@@ -1,7 +1,7 @@
 (library
  (name albatross_stats)
  (public_name albatross.stats)
- (libraries albatross)
+ (libraries albatross albatross.unix)
  (wrapped false)
  (foreign_stubs
   (language c)

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -462,7 +462,7 @@ let resource_add_remove_vm () =
   let u1 =
     Unikernel.{
       config = u ;
-      cmd = Bos.Cmd.v "" ;
+      cmd = Array.make 0 "";
       pid = 0 ;
       taps = [] ;
       digest = Cstruct.empty
@@ -496,7 +496,7 @@ let resource_vm_with_block () =
   let uc3 = { uc2 with block_devices = [ "block", Some "b", None ] } in
   Alcotest.check ok_msg __LOC__ (Error (`Msg "block device not found"))
     Vmm_resources.(check_vm r1 (n_o_s "alpha:bar") uc3);
-  let u = Unikernel.{ config = uc2; cmd = Bos.Cmd.v "" ; pid = 0 ; taps = [] ; digest = Cstruct.empty } in
+  let u = Unikernel.{ config = uc2; cmd = Array.make 0 "" ; pid = 0 ; taps = [] ; digest = Cstruct.empty } in
   let r3 = Vmm_resources.insert_vm r2 (n_o_s "alpha:bar") u in
   Alcotest.check ok_msg __LOC__ (Error (`Msg "block device already in use"))
     Vmm_resources.(check_vm r3 (n_o_s "alpha:bar2") uc2);


### PR DESCRIPTION
The first commit fixes #118 

The second commit moves the unix-dependent parts into albatross.unix, and makes the albatross core library independent of unix (and thus usable in a MirageOS unikernel).