### PR TITLE
Nix: Update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -72,15 +72,11 @@
         "flake-utils": [
           "flake-utils"
         ],
-        "mirage-opam-overlays": [
-          "mirage-opam-overlays"
-        ],
+        "mirage-opam-overlays": "mirage-opam-overlays",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "opam-overlays": [
-          "opam-overlays"
-        ],
+        "opam-overlays": "opam-overlays",
         "opam-repository": [
           "opam-repository"
         ],
@@ -156,10 +152,8 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "mirage-opam-overlays": "mirage-opam-overlays",
         "nixpkgs": "nixpkgs",
         "opam-nix": "opam-nix",
-        "opam-overlays": "opam-overlays",
         "opam-repository": "opam-repository"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -17,12 +17,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -49,16 +52,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663760840,
-        "narHash": "sha256-ym5Iycs5H4cOaLfE2/vC0tsLp8XuBJQIHGV8/uXSy8M=",
-        "owner": "NixOS",
+        "lastModified": 1684935479,
+        "narHash": "sha256-6QMMsXMr2nhmOPHdti2j3KRHt+bai2zw+LJfdCl97Mk=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9bdbbaa634aa666eb6a27096bdcb991c59181244",
+        "rev": "f91ee3065de91a3531329a674a45ddcb3467a650",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "opam-nix": {
@@ -82,11 +87,11 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1665180241,
-        "narHash": "sha256-1VHXIFPy2B4q4hOWH3Koy6r8lWDvmroymMfCX0WQAVk=",
+        "lastModified": 1682411044,
+        "narHash": "sha256-HJY+LANQ75YQSfaTCOnmtiF4pF8d9Eb4dz+wLyNAihE=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "2d2543dd67464345418fd81d9800ebe56a6f6d0c",
+        "rev": "02f7ae28a210e17ca5811b0a4c116acd94e82faa",
         "type": "github"
       },
       "original": {
@@ -98,11 +103,11 @@
     "opam-overlays": {
       "flake": false,
       "locked": {
-        "lastModified": 1667503498,
-        "narHash": "sha256-s1PgYmuWJABbb4J/XyEvZh1s9i8Jqg6GwXVsUsW8uA4=",
+        "lastModified": 1685007198,
+        "narHash": "sha256-e1gmcV68YJcHAtdfPkf6s4JxhtCSnIli8goUWVSIsvY=",
         "owner": "dune-universe",
         "repo": "opam-overlays",
-        "rev": "d97e352e87fc628e1b00e9649f0f552865be791a",
+        "rev": "fcccfb1a2f5727fbc5399ed835a3d5024549252a",
         "type": "github"
       },
       "original": {
@@ -114,11 +119,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1667574627,
-        "narHash": "sha256-FDrvEG9t7SJ/1AIUlmBNYQQrlLbpKt7y+6Bt8K587DA=",
+        "lastModified": 1684925794,
+        "narHash": "sha256-hRUpW0n0pkKnnVXfooHSAKuex8byz2tOqd3Z0DVPTyU=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "3117254d1669a3597b7ed8f51f7ffb0e523e5fd6",
+        "rev": "e10b6ec1ad58b6faa39283ba79fe31b19b2a1897",
         "type": "github"
       },
       "original": {
@@ -135,11 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1651529032,
-        "narHash": "sha256-fe8bm/V/4r2iNxgbitT2sXBqDHQ0GBSnSUSBg/1aXoI=",
+        "lastModified": 1671540003,
+        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
         "owner": "tweag",
         "repo": "opam2json",
-        "rev": "e8e9f2fa86ef124b9f7b8db41d3d19471c1d8901",
+        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
         "type": "github"
       },
       "original": {
@@ -156,6 +161,21 @@
         "opam-nix": "opam-nix",
         "opam-overlays": "opam-overlays",
         "opam-repository": "opam-repository"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "nixpkgs";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   inputs.opam-nix = {
     url = "github:tweag/opam-nix";
     inputs.nixpkgs.follows = "nixpkgs";
@@ -10,7 +10,6 @@
   };
   inputs.flake-utils = {
     url = "github:numtide/flake-utils";
-    inputs.nixpkgs.follows = "nixpkgs";
   };
   inputs.opam-repository = {
     url = "github:ocaml/opam-repository";

--- a/flake.nix
+++ b/flake.nix
@@ -5,22 +5,12 @@
     inputs.nixpkgs.follows = "nixpkgs";
     inputs.flake-utils.follows = "flake-utils";
     inputs.opam-repository.follows = "opam-repository";
-    inputs.opam-overlays.follows = "opam-overlays";
-    inputs.mirage-opam-overlays.follows = "mirage-opam-overlays";
   };
   inputs.flake-utils = {
     url = "github:numtide/flake-utils";
   };
   inputs.opam-repository = {
     url = "github:ocaml/opam-repository";
-    flake = false;
-  };
-  inputs.opam-overlays = {
-    url = "github:dune-universe/opam-overlays";
-    flake = false;
-  };
-  inputs.mirage-opam-overlays = {
-    url = "github:dune-universe/mirage-opam-overlays";
     flake = false;
   };
 


### PR DESCRIPTION
The package requires a more recent version of `opam-repository`, the lock file has to be updated.