### PR TITLE
Update comments for Linux exotic arches

### DIFF
--- a/stats/config/discover.ml
+++ b/stats/config/discover.ml
@@ -37,9 +37,9 @@ let () =
   C.main ~name:"libnl-3-pkg-config" (fun c ->
       match C.ocaml_config_var_exn c "system" with
       | "freebsd" -> freebsd c
+      | "linux_elf"    (* Historically, x86_32 *)
+      | "linux_eabihf" (* Historically, arm32 *)
+      | "elf"          (* Historically, ppc64 & s390x *)
       | "linux" -> linux c
-      | "linux_elf" -> linux c (* x86_32 *)
-      | "linux_eabihf" -> linux c (* arm32 *)
-      | "elf" -> linux c (* ppc64 & s390x *)
       | "macosx" -> niet c (* skip *)
       | os -> failwith ("Unsupported platform: "^os))


### PR DESCRIPTION
ocaml/ocaml#12405 proposes using `linux` everywhere for the "system" variable. The change doesn't semantically affect the script, but it seemed worth a clarifying comment not to _rely_ on the old system values in future.